### PR TITLE
Fix stray prints and trailing text

### DIFF
--- a/backend/app/stripeUtils.py
+++ b/backend/app/stripeUtils.py
@@ -43,6 +43,5 @@ def issue_virtual_card(user_name, user_email):
         cardholder=cardholder.id,
         metadata={"user_email": user_email}
     )
-    
+
     return virtual_card
- 

--- a/backend/run.py
+++ b/backend/run.py
@@ -9,7 +9,6 @@ load_dotenv(dotenv_path=env_path)
 from app.__init__ import create_app
 
 
-print("Hello World! (Remove later just to test if we can get anything to print)")
 app = create_app()
 print("App Created")
 


### PR DESCRIPTION
## Summary
- remove test print from `backend/run.py`
- clean up extra prompt text from `backend/app/stripeUtils.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885ab3af2848325a38ddd36c0d2c818