### PR TITLE
Implement user auth endpoints

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -14,6 +14,14 @@ db = SQLAlchemy()
 bcrypt = Bcrypt()
 # LoginManager for handling user authentication
 login_manager = LoginManager()
+login_manager.session_protection = "strong"
+login_manager.login_view = "api.login"
+
+@login_manager.user_loader
+def load_user(user_id):
+    """Flask-Login user loader callback."""
+    from .models import User
+    return User.query.get(int(user_id))
 
 # Load Stripe secret key, falling back to the value defined in Config
 STRIPE_SECRET_KEY = os.getenv("STRIPE_SECRET_KEY", Config.STRIPE_SECRET_KEY)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -15,6 +15,10 @@ class User(db.Model, UserMixin):
     platform_cards = db.relationship("PlatformGiftCard", back_populates="user")
     transactions = db.relationship("Transaction", back_populates="user")
 
+    def get_id(self):
+        """Return the user identifier for Flask-Login sessions."""
+        return str(self.user_id)
+
 class GiftCard(db.Model):
     __tablename__ = 'gift_cards'
     card_id = db.Column(db.Integer, primary_key=True, autoincrement=True)

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -2,6 +2,8 @@ from cryptography.fernet import Fernet
 import os
 import stripe
 from flask import Blueprint, request, jsonify
+from flask_login import login_user, logout_user, current_user, login_required
+from .__init__ import bcrypt
 from datetime import datetime
 from .config import Config
 
@@ -62,6 +64,59 @@ def verify_payment(payment_intent_id):
 
 # Blueprint exposing REST API endpoints
 api_bp = Blueprint("api", __name__)
+
+
+@api_bp.route("/register", methods=["POST"])
+def register():
+    """Register a new user and log them in."""
+    data = request.get_json() or {}
+    name = data.get("name")
+    email = data.get("email")
+    password = data.get("password")
+    if not all([name, email, password]):
+        return jsonify({"error": "Missing required fields"}), 400
+
+    if User.query.filter_by(email=email).first():
+        return jsonify({"error": "Email already registered"}), 409
+
+    hashed_pw = bcrypt.generate_password_hash(password).decode("utf-8")
+    user = User(name=name, email=email, password_hash=hashed_pw)
+    db.session.add(user)
+    db.session.commit()
+    login_user(user)
+    return jsonify({"message": "registered", "user_id": user.user_id})
+
+
+@api_bp.route("/login", methods=["POST"])
+def login():
+    """Authenticate an existing user."""
+    data = request.get_json() or {}
+    email = data.get("email")
+    password = data.get("password")
+    if not all([email, password]):
+        return jsonify({"error": "Missing credentials"}), 400
+
+    user = User.query.filter_by(email=email).first()
+    if user and bcrypt.check_password_hash(user.password_hash, password):
+        login_user(user)
+        return jsonify({"message": "logged in"})
+    return jsonify({"error": "Invalid credentials"}), 401
+
+
+@api_bp.route("/logout", methods=["POST"])
+@login_required
+def logout():
+    """Log out the current user."""
+    logout_user()
+    return jsonify({"message": "logged out"})
+
+
+@api_bp.route("/session", methods=["GET"])
+def session_info():
+    """Return session status for the current user."""
+    if current_user.is_authenticated:
+        return jsonify({"authenticated": True, "user_id": current_user.user_id})
+    return jsonify({"authenticated": False})
 
 
 @api_bp.route("/gift-cards", methods=["GET"])

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,57 @@
+import os
+import pytest
+
+os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test")
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("SECRET_KEY", "test")
+
+from app.__init__ import create_app, db, bcrypt
+from app.models import User
+
+
+def setup_app():
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def test_register_and_login():
+    app = setup_app()
+    client = app.test_client()
+
+    resp = client.post('/api/register', json={
+        'name': 'Test',
+        'email': 'test@example.com',
+        'password': 'secret'
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['message'] == 'registered'
+
+    with app.app_context():
+        user = User.query.filter_by(email='test@example.com').first()
+        assert user is not None
+        assert bcrypt.check_password_hash(user.password_hash, 'secret')
+
+    client.post('/api/logout')
+
+    resp = client.post('/api/login', json={'email': 'test@example.com', 'password': 'secret'})
+    assert resp.status_code == 200
+    assert resp.get_json()['message'] == 'logged in'
+
+    resp = client.get('/api/session')
+    assert resp.get_json()['authenticated'] is True
+
+
+def test_login_failure():
+    app = setup_app()
+    with app.app_context():
+        pw = bcrypt.generate_password_hash('pw').decode('utf-8')
+        user = User(name='User', email='user@example.com', password_hash=pw)
+        db.session.add(user)
+        db.session.commit()
+
+    client = app.test_client()
+    resp = client.post('/api/login', json={'email': 'user@example.com', 'password': 'wrong'})
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- implement registration, login, logout and session endpoints
- secure user passwords using bcrypt
- configure Flask-Login with user loader
- add unit tests for authentication endpoints

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885aef360848325bb5156cbd6fb5684