### PR TITLE
Add Flask-Migrate support and initial schema

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -34,6 +34,9 @@ def create_app():
     bcrypt.init_app(app)
     login_manager.init_app(app)
 
+    with app.app_context():
+        from . import models  # ensure models are registered for migrations
+
     # Register application blueprints (routes)
     from .routes import api_bp
     from .webhooks import webhooks_bp

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -1,0 +1,12 @@
+from app import create_app, db
+from flask_migrate import Migrate
+
+app = create_app()
+
+migrate = Migrate(app, db)
+
+# Import models for Alembic's autogenerate feature
+from app import models  # noqa: F401
+
+if __name__ == '__main__':
+    app.run()

--- a/backend/migrations/README
+++ b/backend/migrations/README
@@ -1,0 +1,1 @@
+Single-database configuration for Flask.

--- a/backend/migrations/alembic.ini
+++ b/backend/migrations/alembic.ini
@@ -1,0 +1,50 @@
+# A generic, single database configuration.
+
+[alembic]
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic,flask_migrate
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[logger_flask_migrate]
+level = INFO
+handlers =
+qualname = flask_migrate
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -1,0 +1,113 @@
+import logging
+from logging.config import fileConfig
+
+from flask import current_app
+
+from alembic import context
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+logger = logging.getLogger('alembic.env')
+
+
+def get_engine():
+    try:
+        # this works with Flask-SQLAlchemy<3 and Alchemical
+        return current_app.extensions['migrate'].db.get_engine()
+    except (TypeError, AttributeError):
+        # this works with Flask-SQLAlchemy>=3
+        return current_app.extensions['migrate'].db.engine
+
+
+def get_engine_url():
+    try:
+        return get_engine().url.render_as_string(hide_password=False).replace(
+            '%', '%%')
+    except AttributeError:
+        return str(get_engine().url).replace('%', '%%')
+
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+config.set_main_option('sqlalchemy.url', get_engine_url())
+target_db = current_app.extensions['migrate'].db
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def get_metadata():
+    if hasattr(target_db, 'metadatas'):
+        return target_db.metadatas[None]
+    return target_db.metadata
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url, target_metadata=get_metadata(), literal_binds=True
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+
+    # this callback is used to prevent an auto-migration from being generated
+    # when there are no changes to the schema
+    # reference: http://alembic.zzzcomputing.com/en/latest/cookbook.html
+    def process_revision_directives(context, revision, directives):
+        if getattr(config.cmd_opts, 'autogenerate', False):
+            script = directives[0]
+            if script.upgrade_ops.is_empty():
+                directives[:] = []
+                logger.info('No changes in schema detected.')
+
+    conf_args = current_app.extensions['migrate'].configure_args
+    if conf_args.get("process_revision_directives") is None:
+        conf_args["process_revision_directives"] = process_revision_directives
+
+    connectable = get_engine()
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=get_metadata(),
+            **conf_args
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/migrations/script.py.mako
+++ b/backend/migrations/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/backend/migrations/versions/0001_initial.py
+++ b/backend/migrations/versions/0001_initial.py
@@ -1,0 +1,53 @@
+"""initial database schema"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'users',
+        sa.Column('user_id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('email', sa.String(), nullable=False, unique=True),
+        sa.Column('password_hash', sa.String(), nullable=False),
+        sa.Column('is_verified', sa.Boolean(), nullable=True, server_default=sa.text('0')),
+        sa.Column('stripe_customer_id', sa.String(), nullable=True, unique=True),
+    )
+    op.create_table(
+        'gift_cards',
+        sa.Column('card_id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.user_id'), nullable=False),
+        sa.Column('card_number', sa.String(), nullable=False, unique=True),
+        sa.Column('balance', sa.Float(), nullable=False),
+        sa.Column('expiry_date', sa.DateTime(), nullable=False),
+        sa.Column('is_active', sa.Boolean(), nullable=True, server_default=sa.text('1')),
+        sa.Column('source', sa.String(), nullable=False),
+    )
+    op.create_table(
+        'platform_gift_cards',
+        sa.Column('card_id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.user_id'), nullable=False),
+        sa.Column('balance', sa.Float(), nullable=False),
+        sa.Column('stripe_card_id', sa.String(), nullable=True, unique=True),
+    )
+    op.create_table(
+        'transactions',
+        sa.Column('transaction_id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.user_id'), nullable=False),
+        sa.Column('transaction_type', sa.String(), nullable=False),
+        sa.Column('amount', sa.Float(), nullable=False),
+        sa.Column('details_encrypted', sa.String(), nullable=False),
+        sa.Column('stripe_payment_id', sa.String(), nullable=True, unique=True),
+        sa.Column('timestamp', sa.DateTime(), nullable=True, server_default=sa.func.now()),
+    )
+
+def downgrade():
+    op.drop_table('transactions')
+    op.drop_table('platform_gift_cards')
+    op.drop_table('gift_cards')
+    op.drop_table('users')

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,5 @@ cryptography
 stripe
 pytest
 pytest-mock
+Flask-Migrate
+alembic


### PR DESCRIPTION
## Summary
- setup Flask-Migrate for database migrations
- register models on app creation
- add manage.py helper for running migration commands
- generate initial migration creating users, gift cards, platform gift cards and transactions tables
- update dependencies to include Flask-Migrate and Alembic

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885b07629bc832592e969d05fbfebec