### PR TITLE
Implement gift card addition endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,25 @@ pip install -r requirements.txt
 python run.py
 ```
 
+### Gift card management endpoints
+
+You can add physical or imported gift cards to a user's account using the
+`/api/gift-cards` endpoint.
+
+```
+POST /api/gift-cards
+{
+  "user_id": 1,
+  "card_number": "123456789012",
+  "balance": 50,
+  "expiry_date": "2099-12-31",
+  "source": "physical_card"  # or "imported_card"
+}
+```
+
+The API validates the card number format and ensures the expiry date is in the
+future before storing the card.
+
 ## Learn more
 
 To learn more about developing your project with Expo, look at the following resources:

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,5 +1,6 @@
 from cryptography.fernet import Fernet
 import os
+import re
 import stripe
 from flask import Blueprint, request, jsonify
 from flask_login import login_user, logout_user, current_user, login_required
@@ -60,6 +61,19 @@ def verify_payment(payment_intent_id):
         return intent.status == "succeeded"
     except stripe.error.StripeError:
         return False
+
+
+def validate_card_details(card_number: str, expiry_date: str):
+    """Validate card number format and expiry date."""
+    if not re.fullmatch(r"\d{12,19}", str(card_number)):
+        return "Invalid card number"
+    try:
+        exp = datetime.strptime(expiry_date, "%Y-%m-%d")
+    except ValueError:
+        return "Invalid expiry date format"
+    if exp.date() < datetime.utcnow().date():
+        return "Card already expired"
+    return None
 
 
 # Blueprint exposing REST API endpoints
@@ -140,6 +154,49 @@ def get_gift_cards():
             "source": card.source,
         })
     return jsonify(result)
+
+
+@api_bp.route("/gift-cards", methods=["POST"])
+def add_gift_card():
+    """Add a new gift card for a user."""
+    data = request.get_json() or {}
+    user_id = data.get("user_id")
+    card_number = data.get("card_number")
+    balance = data.get("balance")
+    expiry = data.get("expiry_date")
+    source = data.get("source", "physical_card")
+
+    if not all([user_id, card_number, balance, expiry]):
+        return jsonify({"error": "Missing required fields"}), 400
+
+    error = validate_card_details(card_number, expiry)
+    if error:
+        return jsonify({"error": error}), 400
+
+    try:
+        balance = float(balance)
+    except (TypeError, ValueError):
+        return jsonify({"error": "Invalid balance"}), 400
+
+    exp_dt = datetime.strptime(expiry, "%Y-%m-%d")
+
+    existing = GiftCard.query.filter_by(user_id=user_id).all()
+    for card in existing:
+        if decrypt_data(card.card_number) == card_number:
+            return jsonify({"error": "Card already exists"}), 409
+
+    encrypted_number = encrypt_data(card_number)
+
+    new_card = GiftCard(
+        user_id=user_id,
+        card_number=encrypted_number,
+        balance=balance,
+        expiry_date=exp_dt,
+        source=source,
+    )
+    db.session.add(new_card)
+    db.session.commit()
+    return jsonify({"message": "card added", "card_id": new_card.card_id}), 201
 
 
 @api_bp.route("/consolidate", methods=["POST"])

--- a/backend/tests/test_cards.py
+++ b/backend/tests/test_cards.py
@@ -1,0 +1,62 @@
+import os
+import pytest
+
+os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test")
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("SECRET_KEY", "test")
+
+from app.__init__ import create_app, db, bcrypt
+from app.models import User, GiftCard
+
+
+def setup_app():
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def create_user(app):
+    with app.app_context():
+        pw = bcrypt.generate_password_hash('pw').decode('utf-8')
+        user = User(name='U', email='u@example.com', password_hash=pw)
+        db.session.add(user)
+        db.session.commit()
+        return user.user_id
+
+
+def test_add_gift_card_success():
+    app = setup_app()
+    user_id = create_user(app)
+    client = app.test_client()
+
+    resp = client.post('/api/gift-cards', json={
+        'user_id': user_id,
+        'card_number': '123456789012',
+        'balance': 25,
+        'expiry_date': '2099-01-01',
+        'source': 'physical_card'
+    })
+    assert resp.status_code == 201
+    data = resp.get_json()
+    assert data['message'] == 'card added'
+
+    with app.app_context():
+        cards = GiftCard.query.filter_by(user_id=user_id).all()
+        assert len(cards) == 1
+        assert cards[0].balance == 25
+
+
+def test_add_gift_card_expired():
+    app = setup_app()
+    user_id = create_user(app)
+    client = app.test_client()
+
+    resp = client.post('/api/gift-cards', json={
+        'user_id': user_id,
+        'card_number': '123456789012',
+        'balance': 10,
+        'expiry_date': '2000-01-01'
+    })
+    assert resp.status_code == 400
+    assert 'error' in resp.get_json()


### PR DESCRIPTION
## Summary
- add `/api/gift-cards` POST endpoint for adding physical or imported cards
- validate card numbers and expiry dates
- document the new endpoint in README
- add tests covering gift card creation

## Testing
- `pytest -q backend/tests`
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6885b29edaa08325805bd0ef8b84a9d9