### PR TITLE
Implement purchase endpoint

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -338,3 +338,54 @@ def bank_account_transfer():
         "transaction_id": transaction.transaction_id,
         "new_balance": platform_card.balance,
     })
+
+
+@api_bp.route("/purchase", methods=["POST"])
+def make_purchase():
+    """Charge a user's consolidated balance toward a purchase."""
+    data = request.get_json() or {}
+    user_id = data.get("user_id")
+    amount = data.get("amount")
+
+    if not all([user_id, amount]):
+        return jsonify({"error": "Missing required fields"}), 400
+
+    try:
+        amount = float(amount)
+    except (TypeError, ValueError):
+        return jsonify({"error": "Invalid amount"}), 400
+
+    platform_card = PlatformGiftCard.query.filter_by(user_id=user_id).first()
+    if not platform_card or platform_card.balance < amount:
+        return jsonify({"error": "Insufficient balance"}), 400
+
+    stripe_payment_id = None
+    if platform_card.stripe_card_id:
+        try:
+            intent = stripe.PaymentIntent.create(
+                amount=int(amount * 100),
+                currency="usd",
+                payment_method=platform_card.stripe_card_id,
+                confirm=True,
+            )
+            stripe_payment_id = intent.id
+        except stripe.error.StripeError as e:
+            return jsonify({"error": str(e)}), 400
+
+    platform_card.balance -= amount
+
+    transaction = Transaction(
+        user_id=user_id,
+        transaction_type="Purchase",
+        amount=amount,
+        details_encrypted=encrypt_data("Platform card purchase"),
+        stripe_payment_id=stripe_payment_id,
+    )
+    db.session.add(transaction)
+    db.session.commit()
+
+    return jsonify({
+        "message": "purchase successful",
+        "transaction_id": transaction.transaction_id,
+        "remaining_balance": platform_card.balance,
+    })

--- a/backend/tests/test_purchase.py
+++ b/backend/tests/test_purchase.py
@@ -1,0 +1,66 @@
+import os
+
+os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test")
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("SECRET_KEY", "test")
+
+from app.__init__ import create_app, db, bcrypt
+from app.models import User, PlatformGiftCard, Transaction
+
+
+def setup_app():
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def create_user(app):
+    with app.app_context():
+        pw = bcrypt.generate_password_hash("pw").decode("utf-8")
+        user = User(name="U", email="u@example.com", password_hash=pw)
+        db.session.add(user)
+        db.session.commit()
+        return user.user_id
+
+
+def test_purchase_success(mocker):
+    app = setup_app()
+    user_id = create_user(app)
+    client = app.test_client()
+
+    with app.app_context():
+        card = PlatformGiftCard(user_id=user_id, balance=20, stripe_card_id="pm_123")
+        db.session.add(card)
+        db.session.commit()
+
+    mocker.patch("app.routes.stripe.PaymentIntent.create", return_value=type('obj', (object,), {'id': 'pi_789'})())
+
+    resp = client.post('/api/purchase', json={'user_id': user_id, 'amount': 15})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['remaining_balance'] == 5
+
+    with app.app_context():
+        platform = PlatformGiftCard.query.filter_by(user_id=user_id).first()
+        assert platform.balance == 5
+        txns = Transaction.query.filter_by(user_id=user_id).all()
+        assert len(txns) == 1
+        assert txns[0].stripe_payment_id == 'pi_789'
+        assert txns[0].transaction_type == 'Purchase'
+
+
+def test_purchase_insufficient_balance():
+    app = setup_app()
+    user_id = create_user(app)
+    client = app.test_client()
+
+    with app.app_context():
+        card = PlatformGiftCard(user_id=user_id, balance=5)
+        db.session.add(card)
+        db.session.commit()
+
+    resp = client.post('/api/purchase', json={'user_id': user_id, 'amount': 10})
+    assert resp.status_code == 400
+    assert 'error' in resp.get_json()
+


### PR DESCRIPTION
## Summary
- create a `/purchase` API to pay using the consolidated card balance
- integrate purchase flow with `stripe.PaymentIntent`
- test successful and failing purchases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885b58c03708325a3a1ba9ad0a71b35