### PR TITLE
Add frontend flows for bank accounts, top-ups and purchases

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -5,6 +5,9 @@ import { createStackNavigator } from "@react-navigation/stack";
 import HomeScreen from "./HomeScreen";
 import ConsolidationScreen from "./ConsolidationScreen";
 import PaymentScreen from "./PaymentScreen";
+import BankAccountScreen from "./BankAccountScreen";
+import TopUpScreen from "./TopUpScreen";
+import PurchaseScreen from "./PurchaseScreen";
 import { StripeProvider } from "@stripe/stripe-react-native";
 import { getItem, saveItem } from "./SecureStore";
 
@@ -38,6 +41,9 @@ const App = () => {
           <Stack.Screen name="Home" component={HomeScreen} />
           <Stack.Screen name="Consolidate" component={ConsolidationScreen} />
           <Stack.Screen name="Checkout" component={PaymentScreen} />
+          <Stack.Screen name="BankAccounts" component={BankAccountScreen} />
+          <Stack.Screen name="TopUp" component={TopUpScreen} />
+          <Stack.Screen name="Purchase" component={PurchaseScreen} />
         </Stack.Navigator>
       </NavigationContainer>
     </StripeProvider>

--- a/frontend/BankAccountScreen.js
+++ b/frontend/BankAccountScreen.js
@@ -1,0 +1,33 @@
+import React, { useState } from "react";
+import { View, Text, TextInput, Button } from "react-native";
+import { linkBankAccount } from "./api";
+
+const BankAccountScreen = () => {
+  const [bankToken, setBankToken] = useState("");
+  const [message, setMessage] = useState("");
+
+  const handleLink = async () => {
+    const result = await linkBankAccount(1, bankToken);
+    if (result?.message) {
+      setMessage(result.message);
+    } else if (result?.error) {
+      setMessage(result.error);
+    }
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 20 }}>
+      <Text style={{ fontSize: 24, fontWeight: "bold" }}>Link Bank Account</Text>
+      <TextInput
+        placeholder="Bank token"
+        value={bankToken}
+        onChangeText={setBankToken}
+        style={{ borderWidth: 1, padding: 8, marginVertical: 10 }}
+      />
+      <Button title="Link Account" onPress={handleLink} />
+      {message ? <Text style={{ marginTop: 20 }}>{message}</Text> : null}
+    </View>
+  );
+};
+
+export default BankAccountScreen;

--- a/frontend/HomeScreen.js
+++ b/frontend/HomeScreen.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { View, Text, Button, FlatList } from "react-native";
-import { fetchGiftCards, consolidateGiftCards } from "./api";
+import { fetchGiftCards } from "./api";
 
 const HomeScreen = ({ navigation }) => {
   const [giftCards, setGiftCards] = useState([]);
@@ -27,6 +27,9 @@ const HomeScreen = ({ navigation }) => {
         )}
       />
       <Button title="Consolidate" onPress={() => navigation.navigate("Consolidate")} />
+      <Button title="Bank Accounts" onPress={() => navigation.navigate("BankAccounts")} />
+      <Button title="Top Up" onPress={() => navigation.navigate("TopUp")} />
+      <Button title="Purchase" onPress={() => navigation.navigate("Purchase")} />
     </View>
   );
 };

--- a/frontend/PurchaseScreen.js
+++ b/frontend/PurchaseScreen.js
@@ -1,0 +1,34 @@
+import React, { useState } from "react";
+import { View, Text, TextInput, Button } from "react-native";
+import { makePurchase } from "./api";
+
+const PurchaseScreen = () => {
+  const [amount, setAmount] = useState("");
+  const [message, setMessage] = useState("");
+
+  const handlePurchase = async () => {
+    const result = await makePurchase(1, parseFloat(amount));
+    if (result?.remaining_balance !== undefined) {
+      setMessage(`Remaining balance: $${result.remaining_balance}`);
+    } else if (result?.error) {
+      setMessage(result.error);
+    }
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 20 }}>
+      <Text style={{ fontSize: 24, fontWeight: "bold" }}>Purchase</Text>
+      <TextInput
+        placeholder="Amount"
+        value={amount}
+        onChangeText={setAmount}
+        keyboardType="numeric"
+        style={{ borderWidth: 1, padding: 8, marginVertical: 10 }}
+      />
+      <Button title="Make Purchase" onPress={handlePurchase} />
+      {message ? <Text style={{ marginTop: 20 }}>{message}</Text> : null}
+    </View>
+  );
+};
+
+export default PurchaseScreen;

--- a/frontend/TopUpScreen.js
+++ b/frontend/TopUpScreen.js
@@ -1,0 +1,41 @@
+import React, { useState } from "react";
+import { View, Text, TextInput, Button } from "react-native";
+import { transferFromBank } from "./api";
+
+const TopUpScreen = () => {
+  const [accountId, setAccountId] = useState("");
+  const [amount, setAmount] = useState("");
+  const [message, setMessage] = useState("");
+
+  const handleTransfer = async () => {
+    const result = await transferFromBank(1, accountId, parseFloat(amount));
+    if (result?.new_balance !== undefined) {
+      setMessage(`New balance: $${result.new_balance}`);
+    } else if (result?.error) {
+      setMessage(result.error);
+    }
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 20 }}>
+      <Text style={{ fontSize: 24, fontWeight: "bold" }}>Top Up Balance</Text>
+      <TextInput
+        placeholder="Bank Account ID"
+        value={accountId}
+        onChangeText={setAccountId}
+        style={{ borderWidth: 1, padding: 8, marginVertical: 10 }}
+      />
+      <TextInput
+        placeholder="Amount"
+        value={amount}
+        onChangeText={setAmount}
+        keyboardType="numeric"
+        style={{ borderWidth: 1, padding: 8, marginVertical: 10 }}
+      />
+      <Button title="Transfer" onPress={handleTransfer} />
+      {message ? <Text style={{ marginTop: 20 }}>{message}</Text> : null}
+    </View>
+  );
+};
+
+export default TopUpScreen;

--- a/frontend/api.js
+++ b/frontend/api.js
@@ -26,3 +26,45 @@ export const consolidateGiftCards = async (userId) => {
     return null;
   }
 };
+
+export const linkBankAccount = async (userId, bankToken) => {
+  try {
+    const response = await fetch(`${API_URL}/bank-accounts/link`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ user_id: userId, bank_token: bankToken }),
+    });
+    return await response.json();
+  } catch (error) {
+    console.error("Error linking bank account:", error);
+    return null;
+  }
+};
+
+export const transferFromBank = async (userId, accountId, amount) => {
+  try {
+    const response = await fetch(`${API_URL}/bank-accounts/transfer`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ user_id: userId, account_id: accountId, amount }),
+    });
+    return await response.json();
+  } catch (error) {
+    console.error("Error transferring from bank:", error);
+    return null;
+  }
+};
+
+export const makePurchase = async (userId, amount) => {
+  try {
+    const response = await fetch(`${API_URL}/purchase`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ user_id: userId, amount }),
+    });
+    return await response.json();
+  } catch (error) {
+    console.error("Error making purchase:", error);
+    return null;
+  }
+};

--- a/frontend/tests/api.test.js
+++ b/frontend/tests/api.test.js
@@ -1,5 +1,5 @@
 process.env.BACKEND_URL = 'http://your-backend-url';
-const {fetchGiftCards, consolidateGiftCards} = require('../api');
+const {fetchGiftCards, consolidateGiftCards, linkBankAccount, transferFromBank, makePurchase} = require('../api');
 
 global.fetch = jest.fn();
 
@@ -23,4 +23,37 @@ test('consolidateGiftCards posts data', async () => {
     body: JSON.stringify({ user_id: 2 }),
   });
   expect(data).toEqual({message:'ok'});
+});
+
+test('linkBankAccount posts data', async () => {
+  fetch.mockResolvedValue({json: () => Promise.resolve({message:'linked'})});
+  const data = await linkBankAccount(1, 'tok_bank');
+  expect(fetch).toHaveBeenCalledWith('http://your-backend-url/api/bank-accounts/link', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ user_id: 1, bank_token: 'tok_bank' }),
+  });
+  expect(data).toEqual({message:'linked'});
+});
+
+test('transferFromBank posts data', async () => {
+  fetch.mockResolvedValue({json: () => Promise.resolve({new_balance:10})});
+  const data = await transferFromBank(1, 2, 10);
+  expect(fetch).toHaveBeenCalledWith('http://your-backend-url/api/bank-accounts/transfer', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ user_id: 1, account_id: 2, amount: 10 }),
+  });
+  expect(data).toEqual({new_balance:10});
+});
+
+test('makePurchase posts data', async () => {
+  fetch.mockResolvedValue({json: () => Promise.resolve({remaining_balance:5})});
+  const data = await makePurchase(1, 5);
+  expect(fetch).toHaveBeenCalledWith('http://your-backend-url/api/purchase', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ user_id: 1, amount: 5 }),
+  });
+  expect(data).toEqual({remaining_balance:5});
 });


### PR DESCRIPTION
## Summary
- add screens for linking bank accounts, topping up, and making purchases
- expose new API helpers for bank account and purchase endpoints
- hook new screens into the navigation and home screen
- expand frontend API unit tests

## Testing
- `npm install` *(to install jest)*
- `npx jest --silent`

------
https://chatgpt.com/codex/tasks/task_e_6885b6c4c15c8325b93d0c6812dfd682