### PR TITLE
Update Babel config for expo-router

### DIFF
--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -4,4 +4,5 @@ module.exports = {
     ["@babel/preset-env", { targets: { node: 'current' } }],
     '@babel/preset-react',
   ],
+  plugins: ['expo-router/babel'],
 };

--- a/frontend/metro.config.js
+++ b/frontend/metro.config.js
@@ -1,0 +1,10 @@
+const { getDefaultConfig } = require('expo/metro-config');
+
+const config = getDefaultConfig(__dirname);
+
+config.resolver.alias = {
+  ...(config.resolver.alias || {}),
+  '@': __dirname,
+};
+
+module.exports = config;


### PR DESCRIPTION
## Summary
- add `expo-router/babel` plugin
- configure Metro to support `@` alias for imports

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6885c4180c788325ba12a4eb83885f34