### PR TITLE
Check env var for Stripe key

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ Each part can be run and developed independently.
    npm install
    ```
 
-2. Start the app
+2. Set your Stripe publishable key (required)
+
+   ```bash
+   export STRIPE_PUBLISHABLE_KEY=your-publishable-key
+   ```
+
+3. Start the app
 
    ```bash
     npx expo start
@@ -44,7 +50,9 @@ This command will move the starter code to the **app-example** directory and cre
 
 The Expo application stores the Stripe publishable key and recent payment tokens
 using `expo-secure-store`. Storing these values in the device keychain keeps
-credentials out of the codebase and adds a layer of security.
+credentials out of the codebase and adds a layer of security. You can also
+provide a `STRIPE_PUBLISHABLE_KEY` environment variable when starting the app;
+the value will be used before falling back to the stored credentials.
 
 ## Get started (backend)
 

--- a/frontend/App.js
+++ b/frontend/App.js
@@ -20,7 +20,10 @@ const App = () => {
 
   useEffect(() => {
     (async () => {
-      let key = await getItem(STRIPE_KEY_STORAGE);
+      let key = process.env.STRIPE_PUBLISHABLE_KEY;
+      if (!key) {
+        key = await getItem(STRIPE_KEY_STORAGE);
+      }
       if (!key) {
         // Default publishable key used for development/testing
         key = "your-publishable-key";

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -37,6 +37,9 @@
     ],
     "experiments": {
       "typedRoutes": true
+    },
+    "extra": {
+      "stripePublishableKey": "${STRIPE_PUBLISHABLE_KEY}"
     }
   }
 }


### PR DESCRIPTION
## Summary
- load Stripe publishable key from `process.env.STRIPE_PUBLISHABLE_KEY` before falling back to secure store
- document environment variable in README
- mention `STRIPE_PUBLISHABLE_KEY` in app.json

## Testing
- `npm test --silent` in `frontend`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885cfae2e388325bf3fb5401a22d90e