### PR TITLE
Enforce prod DATABASE_URL and add migration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,25 @@ cp backend/.env.example backend/.env
 # then edit backend/.env and add your real credentials
 ```
 
+Your `DATABASE_URL` should use a standard SQLAlchemy connection string. For example:
+
+* **Postgres**: `postgresql://user:password@hostname:5432/dbname`
+* **MySQL**: `mysql+pymysql://user:password@hostname:3306/dbname`
+
+## Database migrations
+
+Flask-Migrate commands are available through `manage.py`. To create or apply
+migrations run:
+
+```bash
+cd backend
+export FLASK_APP=manage.py
+flask db upgrade  # apply existing migrations
+```
+
+Use `flask db migrate -m "Message"` to generate new migration scripts when your
+models change.
+
 ### Gift card management endpoints
 
 You can add physical or imported gift cards to a user's account using the

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -2,8 +2,16 @@
 import os
 
 class Config:
-    SECRET_KEY = os.environ.get('SECRET_KEY') or 'your_secret_key_here'
-    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL', 'sqlite:///site.db')
+    SECRET_KEY = os.environ.get("SECRET_KEY") or "your_secret_key_here"
+
+    env = os.getenv("FLASK_ENV", "production")
+    if env == "development":
+        SQLALCHEMY_DATABASE_URI = os.environ.get("DATABASE_URL", "sqlite:///site.db")
+    else:
+        SQLALCHEMY_DATABASE_URI = os.environ.get("DATABASE_URL")
+        if not SQLALCHEMY_DATABASE_URI:
+            raise RuntimeError("DATABASE_URL must be set for non-development environments")
+
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
     # Stripe Configuration


### PR DESCRIPTION
## Summary
- require DATABASE_URL for production by checking FLASK_ENV
- document DB connection string formats
- add Flask-Migrate instructions for applying migrations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885d09b9ed48325b9170ebe8f772ccc