### PR TITLE
Add Gunicorn deployment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,10 @@ the value will be used before falling back to the stored credentials.
 ```bash
 cd backend
 pip install -r requirements.txt
+# For development
 python run.py
+# For production
+gunicorn wsgi:app
 ```
 
 Before starting the server, create a `.env` file for your local secrets:

--- a/backend/run.py
+++ b/backend/run.py
@@ -1,17 +1,6 @@
-# run.py
-import os
-from dotenv import load_dotenv
+"""Development server entry point."""
 
-# explicitly point to .env file
-env_path = os.path.join(os.path.dirname(__file__), '.env')
-load_dotenv(dotenv_path=env_path)
+from wsgi import app
 
-from app.__init__ import create_app
-
-
-app = create_app()
-print("App Created")
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     app.run(debug=True)
-

--- a/backend/wsgi.py
+++ b/backend/wsgi.py
@@ -1,0 +1,11 @@
+import os
+from dotenv import load_dotenv
+
+# Load environment variables from .env if present
+env_path = os.path.join(os.path.dirname(__file__), '.env')
+if os.path.exists(env_path):
+    load_dotenv(env_path)
+
+from app import create_app
+
+app = create_app()


### PR DESCRIPTION
## Summary
- expose Flask app via `wsgi.py`
- simplify `run.py` for development
- document Gunicorn usage in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885d18eb7ac8325bad1440479ede294