### PR TITLE
Improve backend logging and add rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,16 @@ The server uses [Flask-CORS](https://flask-cors.readthedocs.io/) to allow
 cross-origin requests. Set the `CORS_ORIGINS` environment variable to a
 comma-separated list of allowed origins (defaults to `*`).
 
+### Logging and rate limiting
+
+The API configures Python logging to write to STDOUT by default. Set a `LOG_FILE`
+environment variable if you prefer writing logs to a file. Unexpected errors are
+logged with full stack traces.
+
+All routes are protected by [Flask-Limiter](https://flask-limiter.readthedocs.io/)
+with a default limit of `100/hour` per IP. Adjust this by setting the
+`RATE_LIMIT` environment variable, e.g. `RATE_LIMIT=10/minute`.
+
 Your `DATABASE_URL` should use a standard SQLAlchemy connection string. For example:
 
 * **Postgres**: `postgresql://user:password@hostname:5432/dbname`

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,12 +1,17 @@
 from cryptography.fernet import Fernet
 import os
 import stripe
+import logging
+import sys
+from logging.handlers import RotatingFileHandler
 from flask import Flask
 from flask_wtf import CSRFProtect
 from flask_sqlalchemy import SQLAlchemy
 from flask_bcrypt import Bcrypt
 from flask_login import LoginManager
 from flask_cors import CORS
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
 from .config import Config
 
 # Initialize Flask extensions
@@ -19,6 +24,7 @@ login_manager = LoginManager()
 login_manager.session_protection = "strong"
 login_manager.login_view = "api.login"
 csrf = CSRFProtect()
+limiter = Limiter(key_func=get_remote_address)
 
 @login_manager.user_loader
 def load_user(user_id):
@@ -40,21 +46,34 @@ def create_app():
     app = Flask(__name__)
     app.config.from_object(Config)
 
+    # Configure logging to stdout or a file
+    log_file = os.getenv("LOG_FILE")
+    log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+    handler = RotatingFileHandler(log_file, maxBytes=1048576, backupCount=1) if log_file else logging.StreamHandler(sys.stdout)
+    handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s: %(message)s [in %(pathname)s:%(lineno)d]"))
+    app.logger.setLevel(log_level)
+    app.logger.handlers = [handler]
+
     # Configure CORS origins from environment or configuration
     allowed_origins = os.getenv("CORS_ORIGINS", Config.CORS_ORIGINS)
     origins_list = [o.strip() for o in allowed_origins.split(',')] if allowed_origins else "*"
     CORS(app, origins=origins_list, supports_credentials=True)
 
     # Disable CSRF in testing environments
-    import sys
     if 'pytest' in sys.modules:
         app.config['WTF_CSRF_ENABLED'] = False
+
+    # Update rate limit from environment at runtime
+    app.config['RATELIMIT_DEFAULT'] = os.getenv('RATE_LIMIT', app.config.get('RATELIMIT_DEFAULT', '100/hour'))
 
     # Initialize extensions with the Flask app
     db.init_app(app)
     bcrypt.init_app(app)
     login_manager.init_app(app)
     csrf.init_app(app)
+    app.config.setdefault('RATELIMIT_HEADERS_ENABLED', True)
+    limiter.default_limits = [app.config['RATELIMIT_DEFAULT']]
+    limiter.init_app(app)
 
     with app.app_context():
         from . import models  # ensure models are registered for migrations

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -29,3 +29,6 @@ class Config:
 
     # Comma-separated list of origins allowed to access the API
     CORS_ORIGINS = os.environ.get('CORS_ORIGINS', '*')
+
+    # Global rate limit for the API, used by Flask-Limiter
+    RATE_LIMIT = os.environ.get('RATE_LIMIT', '100/hour')

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -3,6 +3,7 @@ import os
 import re
 import stripe
 from flask import Blueprint, request, jsonify
+from flask_limiter.errors import RateLimitExceeded
 from flask_login import login_user, logout_user, current_user, login_required
 from .__init__ import bcrypt, csrf
 from datetime import datetime
@@ -82,6 +83,10 @@ api_bp = Blueprint("api", __name__)
 
 @api_bp.errorhandler(Exception)
 def handle_exception(error):
+    from flask import current_app
+    if isinstance(error, RateLimitExceeded):
+        return jsonify({"error": "Rate limit exceeded"}), 429
+    current_app.logger.exception("Unhandled exception")
     db.session.rollback()
     return jsonify({"error": "Server error"}), 500
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,3 +11,4 @@ pytest
 pytest-mock
 Flask-Migrate
 alembic
+flask-limiter

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -1,0 +1,57 @@
+import os
+import pytest
+
+os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test")
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("RATE_LIMIT", "1/minute")
+
+from app.__init__ import create_app, db, bcrypt, limiter
+from app.models import User, GiftCard
+
+
+def setup_app():
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+    limiter.reset()
+    return app
+
+
+def create_user(app):
+    with app.app_context():
+        pw = bcrypt.generate_password_hash('pw').decode('utf-8')
+        user = User(name='U', email='u@example.com', password_hash=pw)
+        db.session.add(user)
+        db.session.commit()
+        return user.user_id
+
+
+def test_unhandled_exception_returns_500(mocker):
+    app = setup_app()
+    user_id = create_user(app)
+    client = app.test_client()
+
+    with app.app_context():
+        from datetime import datetime
+        db.session.add(GiftCard(user_id=user_id, card_number='123', balance=10, expiry_date=datetime(2099,1,1), source='physical_card'))
+        db.session.commit()
+
+    mocker.patch('app.routes.stripe.PaymentIntent.create', side_effect=Exception('boom'))
+    resp = client.post('/api/consolidate', json={'user_id': user_id})
+    assert resp.status_code == 500
+    assert resp.get_json()['error'] == 'Server error'
+
+
+def test_rate_limit_headers():
+    app = setup_app()
+    client = app.test_client()
+
+    resp1 = client.get('/api/session')
+    assert resp1.status_code == 200
+
+    resp2 = client.get('/api/session')
+    assert resp2.status_code == 429
+    assert 'Retry-After' in resp2.headers
+    assert resp2.headers.get('X-RateLimit-Remaining') == '0'
+


### PR DESCRIPTION
## Summary
- configure logging to stdout or optional file with stack traces
- add Flask-Limiter with default per-IP limit and headers
- expose RATE_LIMIT config and document usage
- handle RateLimitExceeded with proper 429 response
- add tests for error handling and rate limit headers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885d53b94e48325828a230f1f032267