### PR TITLE
Fix region key in stripe utils

### DIFF
--- a/backend/app/stripeUtils.py
+++ b/backend/app/stripeUtils.py
@@ -28,7 +28,7 @@ def issue_virtual_card(user_name, user_email):
             "address": {
                 "line1": "Placeholder Address",
                 "city": "Placeholder City",
-                "Reigon": "Placeholder Reigon",
+                "region": "Placeholder Reigon",
                 "country": "NZ",
                 "postal_code": "00000"
             }


### PR DESCRIPTION
## Summary
- fix misspelled `Reigon` key in stripeUtils

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885d86b15d483258b01285086aa28c6