### PR TITLE
Add login_required to user routes

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -155,6 +155,7 @@ def session_info():
 
 
 @api_bp.route("/gift-cards", methods=["GET"])
+@login_required
 def get_gift_cards():
     """Return all gift cards for the specified user."""
     user_id = request.args.get("user_id", type=int)
@@ -178,6 +179,7 @@ def get_gift_cards():
 
 
 @api_bp.route("/gift-cards", methods=["POST"])
+@login_required
 def add_gift_card():
     """Add a new gift card for a user."""
     data = request.get_json() or {}
@@ -225,6 +227,7 @@ def add_gift_card():
 
 
 @api_bp.route("/consolidate", methods=["POST"])
+@login_required
 def consolidate_cards():
     """Consolidate all active gift cards into the user's platform card."""
     data = request.get_json() or {}
@@ -268,6 +271,7 @@ def consolidate_cards():
 
 
 @api_bp.route("/bank-accounts/link", methods=["POST"])
+@login_required
 def link_bank_account():
     """Link a user's bank account via Stripe ACH."""
     data = request.get_json() or {}
@@ -314,6 +318,7 @@ def link_bank_account():
 
 
 @api_bp.route("/bank-accounts/transfer", methods=["POST"])
+@login_required
 def bank_account_transfer():
     """Initiate a transfer from a linked bank account and update balance."""
     data = request.get_json() or {}
@@ -379,6 +384,7 @@ def bank_account_transfer():
 
 
 @api_bp.route("/purchase", methods=["POST"])
+@login_required
 def make_purchase():
     """Charge a user's consolidated balance toward a purchase."""
     data = request.get_json() or {}

--- a/backend/tests/test_bank_accounts.py
+++ b/backend/tests/test_bank_accounts.py
@@ -31,6 +31,7 @@ def test_link_bank_account(mocker):
     app = setup_app()
     user_id = create_user(app)
     client = app.test_client()
+    client.post('/api/login', json={'email': 'u@example.com', 'password': 'pw'})
 
     mocker.patch("app.routes.stripe.Customer.create", return_value=type('obj', (object,), {'id': 'cus_123'})())
     mocker.patch("app.routes.stripe.Customer.create_source", return_value=type('obj', (object,), {'id': 'ba_123', 'bank_name': 'Bank', 'last4': '1234'})())
@@ -50,6 +51,7 @@ def test_bank_account_transfer(mocker):
     app = setup_app()
     user_id = create_user(app, with_customer=True)
     client = app.test_client()
+    client.post('/api/login', json={'email': 'u@example.com', 'password': 'pw'})
 
     with app.app_context():
         account = BankAccount(user_id=user_id, stripe_bank_account_id='ba_123', bank_name='Bank', last4='1234')
@@ -72,3 +74,30 @@ def test_bank_account_transfer(mocker):
         assert len(txns) == 1
         assert txns[0].stripe_payment_id == 'pi_123'
         assert txns[0].amount == 15
+
+
+def test_bank_account_transfer_requires_login(mocker):
+    app = setup_app()
+    user_id = create_user(app, with_customer=True)
+    client = app.test_client()
+    with app.app_context():
+        account = BankAccount(user_id=user_id, stripe_bank_account_id='ba_123', bank_name='Bank', last4='1234')
+        db.session.add(account)
+        db.session.add(PlatformGiftCard(user_id=user_id, balance=0))
+        db.session.commit()
+        account_id = account.account_id
+    mocker.patch("app.routes.stripe.PaymentIntent.create", return_value=type('obj', (object,), {'id': 'pi_123'})())
+    resp = client.post('/api/bank-accounts/transfer', json={'user_id': user_id, 'account_id': account_id, 'amount': 15})
+    assert resp.status_code == 302
+
+
+def test_link_bank_account_requires_login(mocker):
+    app = setup_app()
+    user_id = create_user(app)
+    client = app.test_client()
+    mocker.patch("app.routes.stripe.Customer.create", return_value=type('obj', (object,), {'id': 'cus_123'})())
+    mocker.patch("app.routes.stripe.Customer.create_source", return_value=type('obj', (object,), {'id': 'ba_123', 'bank_name': 'Bank', 'last4': '1234'})())
+    resp = client.post('/api/bank-accounts/link', json={'user_id': user_id, 'bank_token': 'tok_bank'})
+    assert resp.status_code == 302
+
+

--- a/backend/tests/test_cards.py
+++ b/backend/tests/test_cards.py
@@ -29,6 +29,7 @@ def test_add_gift_card_success():
     app = setup_app()
     user_id = create_user(app)
     client = app.test_client()
+    client.post('/api/login', json={'email': 'u@example.com', 'password': 'pw'})
 
     resp = client.post('/api/gift-cards', json={
         'user_id': user_id,
@@ -51,6 +52,7 @@ def test_add_gift_card_expired():
     app = setup_app()
     user_id = create_user(app)
     client = app.test_client()
+    client.post('/api/login', json={'email': 'u@example.com', 'password': 'pw'})
 
     resp = client.post('/api/gift-cards', json={
         'user_id': user_id,
@@ -60,3 +62,12 @@ def test_add_gift_card_expired():
     })
     assert resp.status_code == 400
     assert 'error' in resp.get_json()
+
+
+def test_get_cards_requires_login():
+    app = setup_app()
+    user_id = create_user(app)
+    client = app.test_client()
+    resp = client.get(f'/api/gift-cards?user_id={user_id}')
+    assert resp.status_code == 302
+

--- a/backend/tests/test_consolidate.py
+++ b/backend/tests/test_consolidate.py
@@ -38,6 +38,7 @@ def test_consolidate_cards(mocker):
     app = setup_app()
     user_id = create_user_with_cards(app)
     client = app.test_client()
+    client.post('/api/login', json={'email': 'u@example.com', 'password': 'pw'})
 
     mocker.patch('app.routes.stripe.PaymentIntent.create', return_value=type('obj',(object,),{'client_secret':'secret'})())
 
@@ -54,3 +55,13 @@ def test_consolidate_cards(mocker):
         cards = GiftCard.query.filter_by(user_id=user_id).all()
         assert all(card.balance == 0 for card in cards)
         assert all(card.is_active is False for card in cards)
+
+
+def test_consolidate_requires_login(mocker):
+    app = setup_app()
+    user_id = create_user_with_cards(app)
+    client = app.test_client()
+    mocker.patch('app.routes.stripe.PaymentIntent.create', return_value=type('obj',(object,),{'client_secret':'secret'})())
+    resp = client.post('/api/consolidate', json={'user_id': user_id})
+    assert resp.status_code == 302
+

--- a/backend/tests/test_purchase.py
+++ b/backend/tests/test_purchase.py
@@ -28,6 +28,7 @@ def test_purchase_success(mocker):
     app = setup_app()
     user_id = create_user(app)
     client = app.test_client()
+    client.post('/api/login', json={'email': 'u@example.com', 'password': 'pw'})
 
     with app.app_context():
         card = PlatformGiftCard(user_id=user_id, balance=20, stripe_card_id="pm_123")
@@ -54,6 +55,7 @@ def test_purchase_insufficient_balance():
     app = setup_app()
     user_id = create_user(app)
     client = app.test_client()
+    client.post('/api/login', json={'email': 'u@example.com', 'password': 'pw'})
 
     with app.app_context():
         card = PlatformGiftCard(user_id=user_id, balance=5)
@@ -63,4 +65,17 @@ def test_purchase_insufficient_balance():
     resp = client.post('/api/purchase', json={'user_id': user_id, 'amount': 10})
     assert resp.status_code == 400
     assert 'error' in resp.get_json()
+
+
+def test_purchase_requires_login():
+    app = setup_app()
+    user_id = create_user(app)
+    client = app.test_client()
+    with app.app_context():
+        card = PlatformGiftCard(user_id=user_id, balance=5)
+        db.session.add(card)
+        db.session.commit()
+    resp = client.post('/api/purchase', json={'user_id': user_id, 'amount': 3})
+    assert resp.status_code == 302
+
 

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -31,6 +31,7 @@ def test_unhandled_exception_returns_500(mocker):
     app = setup_app()
     user_id = create_user(app)
     client = app.test_client()
+    client.post('/api/login', json={'email': 'u@example.com', 'password': 'pw'})
 
     with app.app_context():
         from datetime import datetime


### PR DESCRIPTION
## Summary
- restrict access to user-specific API routes
- adjust test cases to log in and verify login requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885da83a89483259164e476815879b0