### PR TITLE
Remove key and document env var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ app-example
 
 # backend archives
 backend/*.zip
+backend/encryption_key.key

--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ cp backend/.env.example backend/.env
 # then edit backend/.env and add your real credentials
 ```
 
+Make sure to define an `ENCRYPTION_KEY` in this file or in your environment. The
+example file `backend/.env.example` shows the variable name. This key is used to
+encrypt sensitive data stored by the API.
+
 The server uses [Flask-CORS](https://flask-cors.readthedocs.io/) to allow
 cross-origin requests. Set the `CORS_ORIGINS` environment variable to a
 comma-separated list of allowed origins (defaults to `*`).


### PR DESCRIPTION
## Summary
- ignore `backend/encryption_key.key`
- document `ENCRYPTION_KEY` env variable

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6885dbe006c483259175e8476ed6df8c