### PR TITLE
Add authentication screens and context

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -1,5 +1,5 @@
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useContext } from "react";
 import { NavigationContainer } from "@react-navigation/native";
 import { createStackNavigator } from "@react-navigation/stack";
 import HomeScreen from "./HomeScreen";
@@ -8,12 +8,42 @@ import PaymentScreen from "./PaymentScreen";
 import BankAccountScreen from "./BankAccountScreen";
 import TopUpScreen from "./TopUpScreen";
 import PurchaseScreen from "./PurchaseScreen";
+import LoginScreen from "./LoginScreen";
+import RegisterScreen from "./RegisterScreen";
 import { StripeProvider } from "@stripe/stripe-react-native";
 import { getItem, saveItem } from "./SecureStore";
-
-const Stack = createStackNavigator();
+import { AuthProvider, AuthContext } from "./AuthContext";
 
 const STRIPE_KEY_STORAGE = "stripe_publishable_key";
+
+const AppNavigator = () => {
+  const { user, loading } = useContext(AuthContext);
+  const Stack = createStackNavigator();
+
+  if (loading) return null;
+
+  return (
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName={user ? 'Home' : 'Login'}>
+        {user ? (
+          <>
+            <Stack.Screen name="Home" component={HomeScreen} />
+            <Stack.Screen name="Consolidate" component={ConsolidationScreen} />
+            <Stack.Screen name="Checkout" component={PaymentScreen} />
+            <Stack.Screen name="BankAccounts" component={BankAccountScreen} />
+            <Stack.Screen name="TopUp" component={TopUpScreen} />
+            <Stack.Screen name="Purchase" component={PurchaseScreen} />
+          </>
+        ) : (
+          <>
+            <Stack.Screen name="Login" component={LoginScreen} />
+            <Stack.Screen name="Register" component={RegisterScreen} />
+          </>
+        )}
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+};
 
 const App = () => {
   const [publishableKey, setPublishableKey] = useState(null);
@@ -39,16 +69,9 @@ const App = () => {
 
   return (
     <StripeProvider publishableKey={publishableKey}>
-      <NavigationContainer>
-        <Stack.Navigator initialRouteName="Home">
-          <Stack.Screen name="Home" component={HomeScreen} />
-          <Stack.Screen name="Consolidate" component={ConsolidationScreen} />
-          <Stack.Screen name="Checkout" component={PaymentScreen} />
-          <Stack.Screen name="BankAccounts" component={BankAccountScreen} />
-          <Stack.Screen name="TopUp" component={TopUpScreen} />
-          <Stack.Screen name="Purchase" component={PurchaseScreen} />
-        </Stack.Navigator>
-      </NavigationContainer>
+      <AuthProvider>
+        <AppNavigator />
+      </AuthProvider>
     </StripeProvider>
   );
 };

--- a/frontend/AuthContext.js
+++ b/frontend/AuthContext.js
@@ -1,0 +1,72 @@
+import React, { createContext, useState, useEffect } from 'react';
+import { getItem, saveItem, deleteItem } from './SecureStore';
+import { loginUser, registerUser, logoutUser, sessionInfo } from './api';
+
+export const AuthContext = createContext({
+  user: null,
+  loading: true,
+  login: async () => {},
+  register: async () => {},
+  logout: async () => {},
+});
+
+const STORAGE_KEY = 'auth_user';
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      const stored = await getItem(STORAGE_KEY);
+      if (stored) {
+        try {
+          const parsed = JSON.parse(stored);
+          if (parsed && parsed.user_id) {
+            setUser(parsed);
+          }
+        } catch {}
+      }
+      setLoading(false);
+    })();
+  }, []);
+
+  const login = async (email, password) => {
+    const data = await loginUser(email, password);
+    if (!data?.error) {
+      let uid = data.user_id;
+      if (!uid) {
+        const session = await sessionInfo();
+        uid = session?.user_id;
+      }
+      if (uid) {
+        const userData = { user_id: uid };
+        await saveItem(STORAGE_KEY, JSON.stringify(userData));
+        setUser(userData);
+      }
+    }
+    return data;
+  };
+
+  const register = async (name, email, password) => {
+    const data = await registerUser(name, email, password);
+    if (!data?.error && data.user_id) {
+      const userData = { user_id: data.user_id };
+      await saveItem(STORAGE_KEY, JSON.stringify(userData));
+      setUser(userData);
+    }
+    return data;
+  };
+
+  const logout = async () => {
+    await logoutUser();
+    await deleteItem(STORAGE_KEY);
+    setUser(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, loading, login, register, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/frontend/BankAccountScreen.js
+++ b/frontend/BankAccountScreen.js
@@ -1,18 +1,21 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import { View, TextInput, Button, StyleSheet } from "react-native";
 import { linkBankAccount } from "./api";
 import { ThemedText } from "./ThemedText";
 import { useColorScheme } from "./hooks/useColorScheme";
 import { Colors } from "./constants/Colors";
+import { AuthContext } from "./AuthContext";
 
 const BankAccountScreen = () => {
+  const { user } = useContext(AuthContext);
   const [bankToken, setBankToken] = useState("");
   const [message, setMessage] = useState("");
   const theme = useColorScheme() ?? "light";
   const tint = Colors[theme].tint;
 
   const handleLink = async () => {
-    const result = await linkBankAccount(1, bankToken);
+    if (!user) return;
+    const result = await linkBankAccount(user.user_id, bankToken);
     if (result?.message) {
       setMessage(result.message);
     } else if (result?.error) {

--- a/frontend/ConsolidationScreen.js
+++ b/frontend/ConsolidationScreen.js
@@ -1,20 +1,23 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import { View, Button, ActivityIndicator, StyleSheet } from "react-native";
 import { consolidateGiftCards } from "./api";
 import { ThemedText } from "./ThemedText";
 import { useColorScheme } from "./hooks/useColorScheme";
 import { Colors } from "./constants/Colors";
+import { AuthContext } from "./AuthContext";
 
 
 const ConsolidationScreen = ({ navigation }) => {
+  const { user } = useContext(AuthContext);
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState("");
   const theme = useColorScheme() ?? "light";
   const tint = Colors[theme].tint;
 
   const handleConsolidation = async () => {
+    if (!user) return;
     setLoading(true);
-    const result = await consolidateGiftCards(1);
+    const result = await consolidateGiftCards(user.user_id);
     setLoading(false);
     if (result?.message) {
       setMessage(result.message);

--- a/frontend/HomeScreen.js
+++ b/frontend/HomeScreen.js
@@ -1,22 +1,25 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useContext } from "react";
 import { View, Button, FlatList, StyleSheet } from "react-native";
 import { fetchGiftCards } from "./api";
 import { ThemedText } from "./ThemedText";
 import { useColorScheme } from "./hooks/useColorScheme";
 import { Colors } from "./constants/Colors";
+import { AuthContext } from "./AuthContext";
 
 const HomeScreen = ({ navigation }) => {
+  const { user } = useContext(AuthContext);
   const [giftCards, setGiftCards] = useState([]);
   const theme = useColorScheme() ?? "light";
   const tint = Colors[theme].tint;
 
   useEffect(() => {
     const loadGiftCards = async () => {
-      const data = await fetchGiftCards(1); // Assume user_id = 1
+      if (!user) return;
+      const data = await fetchGiftCards(user.user_id);
       setGiftCards(data);
     };
     loadGiftCards();
-  }, []);
+  }, [user]);
 
   return (
     <View style={[styles.container, { backgroundColor: Colors[theme].background }]}>

--- a/frontend/LoginScreen.js
+++ b/frontend/LoginScreen.js
@@ -1,0 +1,69 @@
+import React, { useState, useContext } from 'react';
+import { View, TextInput, Button, StyleSheet, TouchableOpacity } from 'react-native';
+import { ThemedText } from './ThemedText';
+import { useColorScheme } from './hooks/useColorScheme';
+import { Colors } from './constants/Colors';
+import { AuthContext } from './AuthContext';
+
+const LoginScreen = ({ navigation }) => {
+  const { login } = useContext(AuthContext);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+  const theme = useColorScheme() ?? 'light';
+  const tint = Colors[theme].tint;
+
+  const handleLogin = async () => {
+    const res = await login(email, password);
+    if (res?.error) {
+      setMessage(res.error);
+    }
+  };
+
+  return (
+    <View style={[styles.container, { backgroundColor: Colors[theme].background }] }>
+      <ThemedText style={styles.title}>Login</ThemedText>
+      <TextInput placeholder="Email" value={email} onChangeText={setEmail} style={styles.input} />
+      <TextInput
+        placeholder="Password"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+        style={styles.input}
+      />
+      <Button color={tint} title="Login" onPress={handleLogin} />
+      {message ? <ThemedText style={styles.message}>{message}</ThemedText> : null}
+      <TouchableOpacity onPress={() => navigation.navigate('Register')}>
+        <ThemedText style={[styles.link, {color: tint}]}>Create account</ThemedText>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+export default LoginScreen;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 20,
+  },
+  input: {
+    borderWidth: 1,
+    padding: 8,
+    marginVertical: 10,
+    borderRadius: 6,
+  },
+  message: {
+    marginTop: 20,
+  },
+  link: {
+    marginTop: 15,
+    textAlign: 'center',
+  },
+});

--- a/frontend/PurchaseScreen.js
+++ b/frontend/PurchaseScreen.js
@@ -1,18 +1,21 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import { View, TextInput, Button, StyleSheet } from "react-native";
 import { makePurchase } from "./api";
 import { ThemedText } from "./ThemedText";
 import { useColorScheme } from "./hooks/useColorScheme";
 import { Colors } from "./constants/Colors";
+import { AuthContext } from "./AuthContext";
 
 const PurchaseScreen = () => {
+  const { user } = useContext(AuthContext);
   const [amount, setAmount] = useState("");
   const [message, setMessage] = useState("");
   const theme = useColorScheme() ?? "light";
   const tint = Colors[theme].tint;
 
   const handlePurchase = async () => {
-    const result = await makePurchase(1, parseFloat(amount));
+    if (!user) return;
+    const result = await makePurchase(user.user_id, parseFloat(amount));
     if (result?.remaining_balance !== undefined) {
       setMessage(`Remaining balance: $${result.remaining_balance}`);
     } else if (result?.error) {

--- a/frontend/RegisterScreen.js
+++ b/frontend/RegisterScreen.js
@@ -1,0 +1,71 @@
+import React, { useState, useContext } from 'react';
+import { View, TextInput, Button, StyleSheet, TouchableOpacity } from 'react-native';
+import { ThemedText } from './ThemedText';
+import { useColorScheme } from './hooks/useColorScheme';
+import { Colors } from './constants/Colors';
+import { AuthContext } from './AuthContext';
+
+const RegisterScreen = ({ navigation }) => {
+  const { register } = useContext(AuthContext);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+  const theme = useColorScheme() ?? 'light';
+  const tint = Colors[theme].tint;
+
+  const handleRegister = async () => {
+    const res = await register(name, email, password);
+    if (res?.error) {
+      setMessage(res.error);
+    }
+  };
+
+  return (
+    <View style={[styles.container, { backgroundColor: Colors[theme].background }] }>
+      <ThemedText style={styles.title}>Register</ThemedText>
+      <TextInput placeholder="Name" value={name} onChangeText={setName} style={styles.input} />
+      <TextInput placeholder="Email" value={email} onChangeText={setEmail} style={styles.input} />
+      <TextInput
+        placeholder="Password"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+        style={styles.input}
+      />
+      <Button color={tint} title="Register" onPress={handleRegister} />
+      {message ? <ThemedText style={styles.message}>{message}</ThemedText> : null}
+      <TouchableOpacity onPress={() => navigation.navigate('Login')}>
+        <ThemedText style={[styles.link, {color: tint}]}>Back to Login</ThemedText>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+export default RegisterScreen;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 20,
+  },
+  input: {
+    borderWidth: 1,
+    padding: 8,
+    marginVertical: 10,
+    borderRadius: 6,
+  },
+  message: {
+    marginTop: 20,
+  },
+  link: {
+    marginTop: 15,
+    textAlign: 'center',
+  },
+});

--- a/frontend/TopUpScreen.js
+++ b/frontend/TopUpScreen.js
@@ -1,11 +1,13 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import { View, TextInput, Button, StyleSheet } from "react-native";
 import { transferFromBank } from "./api";
 import { ThemedText } from "./ThemedText";
 import { useColorScheme } from "./hooks/useColorScheme";
 import { Colors } from "./constants/Colors";
+import { AuthContext } from "./AuthContext";
 
 const TopUpScreen = () => {
+  const { user } = useContext(AuthContext);
   const [accountId, setAccountId] = useState("");
   const [amount, setAmount] = useState("");
   const [message, setMessage] = useState("");
@@ -13,7 +15,8 @@ const TopUpScreen = () => {
   const tint = Colors[theme].tint;
 
   const handleTransfer = async () => {
-    const result = await transferFromBank(1, accountId, parseFloat(amount));
+    if (!user) return;
+    const result = await transferFromBank(user.user_id, accountId, parseFloat(amount));
     if (result?.new_balance !== undefined) {
       setMessage(`New balance: $${result.new_balance}`);
     } else if (result?.error) {

--- a/frontend/api.js
+++ b/frontend/api.js
@@ -5,7 +5,9 @@ const API_URL = `${API_BASE}/api`;
 
 export const fetchGiftCards = async (userId) => {
   try {
-    const response = await fetch(`${API_URL}/gift-cards?user_id=${userId}`);
+    const response = await fetch(`${API_URL}/gift-cards?user_id=${userId}`, {
+      credentials: 'include',
+    });
     return await response.json();
   } catch (error) {
     console.error("Error fetching gift cards:", error);
@@ -19,6 +21,7 @@ export const consolidateGiftCards = async (userId) => {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ user_id: userId }),
+      credentials: 'include',
     });
     return await response.json();
   } catch (error) {
@@ -33,6 +36,7 @@ export const linkBankAccount = async (userId, bankToken) => {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ user_id: userId, bank_token: bankToken }),
+      credentials: 'include',
     });
     return await response.json();
   } catch (error) {
@@ -47,6 +51,7 @@ export const transferFromBank = async (userId, accountId, amount) => {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ user_id: userId, account_id: accountId, amount }),
+      credentials: 'include',
     });
     return await response.json();
   } catch (error) {
@@ -61,10 +66,59 @@ export const makePurchase = async (userId, amount) => {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ user_id: userId, amount }),
+      credentials: 'include',
     });
     return await response.json();
   } catch (error) {
     console.error("Error making purchase:", error);
+    return null;
+  }
+};
+
+export const registerUser = async (name, email, password) => {
+  try {
+    const response = await fetch(`${API_URL}/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, email, password }),
+      credentials: 'include',
+    });
+    return await response.json();
+  } catch (error) {
+    console.error('Error registering:', error);
+    return { error: 'network_error' };
+  }
+};
+
+export const loginUser = async (email, password) => {
+  try {
+    const response = await fetch(`${API_URL}/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+      credentials: 'include',
+    });
+    return await response.json();
+  } catch (error) {
+    console.error('Error logging in:', error);
+    return { error: 'network_error' };
+  }
+};
+
+export const logoutUser = async () => {
+  try {
+    await fetch(`${API_URL}/logout`, { method: 'POST', credentials: 'include' });
+  } catch (error) {
+    console.error('Error logging out:', error);
+  }
+};
+
+export const sessionInfo = async () => {
+  try {
+    const res = await fetch(`${API_URL}/session`, { credentials: 'include' });
+    return await res.json();
+  } catch (error) {
+    console.error('Error fetching session:', error);
     return null;
   }
 };

--- a/frontend/tests/api.test.js
+++ b/frontend/tests/api.test.js
@@ -10,7 +10,7 @@ afterEach(() => {
 test('fetchGiftCards makes request to correct URL', async () => {
   fetch.mockResolvedValue({json: () => Promise.resolve([{card_id:1}])});
   const data = await fetchGiftCards(1);
-  expect(fetch).toHaveBeenCalledWith('http://your-backend-url/api/gift-cards?user_id=1');
+  expect(fetch).toHaveBeenCalledWith('http://your-backend-url/api/gift-cards?user_id=1', { credentials: 'include' });
   expect(data).toEqual([{card_id:1}]);
 });
 
@@ -21,6 +21,7 @@ test('consolidateGiftCards posts data', async () => {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ user_id: 2 }),
+    credentials: 'include',
   });
   expect(data).toEqual({message:'ok'});
 });
@@ -32,6 +33,7 @@ test('linkBankAccount posts data', async () => {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ user_id: 1, bank_token: 'tok_bank' }),
+    credentials: 'include',
   });
   expect(data).toEqual({message:'linked'});
 });
@@ -43,6 +45,7 @@ test('transferFromBank posts data', async () => {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ user_id: 1, account_id: 2, amount: 10 }),
+    credentials: 'include',
   });
   expect(data).toEqual({new_balance:10});
 });
@@ -54,6 +57,7 @@ test('makePurchase posts data', async () => {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ user_id: 1, amount: 5 }),
+    credentials: 'include',
   });
   expect(data).toEqual({remaining_balance:5});
 });

--- a/frontend/tests/bankFlows.test.js
+++ b/frontend/tests/bankFlows.test.js
@@ -15,7 +15,14 @@ jest.mock('react-native', () => {
 import BankAccountScreen from '../BankAccountScreen';
 import TopUpScreen from '../TopUpScreen';
 import PurchaseScreen from '../PurchaseScreen';
+import { AuthContext } from '../AuthContext';
 import { linkBankAccount, transferFromBank, makePurchase } from '../api';
+
+jest.mock('../SecureStore', () => ({
+  getItem: jest.fn(),
+  saveItem: jest.fn(),
+  deleteItem: jest.fn(),
+}));
 
 jest.mock('../api');
 
@@ -28,7 +35,11 @@ describe('banking flows', () => {
     linkBankAccount.mockResolvedValue({ message: 'bank account linked' });
     let tree;
     await act(async () => {
-      tree = renderer.create(<BankAccountScreen />);
+      tree = renderer.create(
+        <AuthContext.Provider value={{ user: { user_id: 1 } }}>
+          <BankAccountScreen />
+        </AuthContext.Provider>
+      );
     });
     const root = tree.root;
     const input = root.findByProps({ placeholder: 'Bank token' });
@@ -48,7 +59,11 @@ describe('banking flows', () => {
     transferFromBank.mockResolvedValue({ new_balance: 15 });
     let tree;
     await act(async () => {
-      tree = renderer.create(<TopUpScreen />);
+      tree = renderer.create(
+        <AuthContext.Provider value={{ user: { user_id: 1 } }}>
+          <TopUpScreen />
+        </AuthContext.Provider>
+      );
     });
     const root = tree.root;
     const accInput = root.findByProps({ placeholder: 'Bank Account ID' });
@@ -70,7 +85,11 @@ describe('banking flows', () => {
     makePurchase.mockResolvedValue({ remaining_balance: 5 });
     let tree;
     await act(async () => {
-      tree = renderer.create(<PurchaseScreen />);
+      tree = renderer.create(
+        <AuthContext.Provider value={{ user: { user_id: 1 } }}>
+          <PurchaseScreen />
+        </AuthContext.Provider>
+      );
     });
     const root = tree.root;
     const input = root.findByProps({ placeholder: 'Amount' });


### PR DESCRIPTION
## Summary
- store auth state in new `AuthContext` using `expo-secure-store`
- add login and register screens
- persist user ID and use it in API calls
- inject auth-aware navigation in `App.js`
- update API helpers to send cookies and add auth endpoints
- adjust screens and tests for new auth flow

## Testing
- `cd frontend && npx --yes jest`

------
https://chatgpt.com/codex/tasks/task_e_6885dcd412548325ab4e127fec2f3a0f