### PR TITLE
Add Docker support for backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,25 @@ python run.py
 gunicorn wsgi:app
 ```
 
+### Docker
+
+You can build the API server into a container using the provided Dockerfile:
+
+```bash
+docker build -t consolidator-backend ./backend
+docker run --env-file backend/.env -p 8000:8000 consolidator-backend
+```
+
+A `docker-compose.yml` file is included to run the backend together with a
+persistent Redis instance used by Flask-Limiter:
+
+```bash
+docker compose up
+```
+
+The API will be available at `http://localhost:8000` and Redis data will be
+stored in the `redis-data` volume.
+
 Before starting the server, create a `.env` file for your local secrets:
 
 ```bash

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+CMD ["gunicorn", "wsgi:app", "-b", "0.0.0.0:8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.8'
+services:
+  backend:
+    build: ./backend
+    env_file:
+      - ./backend/.env
+    ports:
+      - "8000:8000"
+    environment:
+      RATELIMIT_STORAGE_URL: redis://redis:6379/0
+    depends_on:
+      - redis
+  redis:
+    image: redis:7
+    volumes:
+      - redis-data:/data
+volumes:
+  redis-data:


### PR DESCRIPTION
## Summary
- add Dockerfile for running the Flask backend with gunicorn
- include docker-compose to run the backend and a Redis container
- document Docker usage in the README

## Testing
- `pytest -q`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_6885dfca9c088325bd42107939adff85