### PR TITLE
Add Unix installer wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,3 +293,14 @@ run_installer.bat
 ```
 
 The script installs Python packages, builds `backend/run.py` into `backend/dist/run.exe` using PyInstaller and installs the frontend npm packages. After completion, you can execute the generated `run.exe` to start the Flask API.
+
+## Unix installer
+
+For Linux or macOS users, a small wrapper script is provided. Run:
+
+```bash
+./run_installer.sh
+```
+
+This invokes `installer.py` using Python 3 to install all dependencies and build
+the backend executable.

--- a/run_installer.sh
+++ b/run_installer.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Simple installer wrapper for Unix-like systems
+python3 "$(dirname "$0")/installer.py" "$@"


### PR DESCRIPTION
## Summary
- add a simple shell script `run_installer.sh` for Unix systems
- document the new installer script in the README

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885f3529a688325b9e4fd133bcba0da