### PR TITLE
Remove client tokenization of bank details

### DIFF
--- a/frontend/api.js
+++ b/frontend/api.js
@@ -36,7 +36,7 @@ export const linkBankAccount = async (userId, bankToken) => {
     const response = await fetch(`${API_URL}/bank-accounts/link`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ user_id: userId, bank_token: tokenize(bankToken) }),
+      body: JSON.stringify({ user_id: userId, bank_token: bankToken }),
       credentials: 'include',
     });
     return await response.json();
@@ -51,7 +51,7 @@ export const transferFromBank = async (userId, accountId, amount) => {
     const response = await fetch(`${API_URL}/bank-accounts/transfer`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ user_id: userId, account_id: tokenize(accountId), amount }),
+      body: JSON.stringify({ user_id: userId, account_id: accountId, amount }),
       credentials: 'include',
     });
     return await response.json();

--- a/frontend/tests/api.test.js
+++ b/frontend/tests/api.test.js
@@ -1,6 +1,5 @@
 process.env.BACKEND_URL = 'http://your-backend-url';
 const {fetchGiftCards, consolidateGiftCards, linkBankAccount, transferFromBank, makePurchase} = require('../api');
-const { tokenize } = require('../tokenizer');
 
 global.fetch = jest.fn();
 
@@ -33,7 +32,7 @@ test('linkBankAccount posts data', async () => {
   expect(fetch).toHaveBeenCalledWith('http://your-backend-url/api/bank-accounts/link', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ user_id: 1, bank_token: tokenize('tok_bank') }),
+    body: JSON.stringify({ user_id: 1, bank_token: 'tok_bank' }),
     credentials: 'include',
   });
   expect(data).toEqual({message:'linked'});
@@ -45,7 +44,7 @@ test('transferFromBank posts data', async () => {
   expect(fetch).toHaveBeenCalledWith('http://your-backend-url/api/bank-accounts/transfer', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ user_id: 1, account_id: tokenize(2), amount: 10 }),
+    body: JSON.stringify({ user_id: 1, account_id: 2, amount: 10 }),
     credentials: 'include',
   });
   expect(data).toEqual({new_balance:10});


### PR DESCRIPTION
## Summary
- stop hashing `bank_token` and `account_id` when linking or transferring funds
- update tests for new request bodies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886af5175d0832584c5f77aaa05e804