### PR TITLE
Refactor encryption helpers

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,7 +1,7 @@
-from cryptography.fernet import Fernet
 import os
 import re
 import stripe
+from .encryption_utils import encrypt_data, decrypt_data
 from flask import Blueprint, request, jsonify
 from flask_limiter.errors import RateLimitExceeded
 from flask_login import login_user, logout_user, current_user, login_required
@@ -11,37 +11,8 @@ from .config import Config
 
 from .models import db, GiftCard, PlatformGiftCard, User, Transaction, BankAccount
 
-# Load encryption key from environment variable or file
-ENCRYPTION_KEY_PATH = os.getenv("ENCRYPTION_KEY_PATH", "encryption_key.key")
 STRIPE_SECRET_KEY = os.getenv("STRIPE_SECRET_KEY", Config.STRIPE_SECRET_KEY)
 stripe.api_key = STRIPE_SECRET_KEY
-
-def load_encryption_key():
-    if os.getenv("ENCRYPTION_KEY"):  # Load from environment variable if available
-        return os.getenv("ENCRYPTION_KEY").encode()
-
-    if os.path.exists(ENCRYPTION_KEY_PATH):
-        with open(ENCRYPTION_KEY_PATH, "rb") as key_file:
-            return key_file.read()
-    else:
-        key = Fernet.generate_key()
-        with open(ENCRYPTION_KEY_PATH, "wb") as key_file:
-            key_file.write(key)
-        return key
-
-encryption_key = load_encryption_key()
-cipher = Fernet(encryption_key)
-
-def encrypt_data(data):
-    """Encrypts a string using Fernet encryption."""
-    return cipher.encrypt(data.encode()).decode()
-
-def decrypt_data(encrypted_data):
-    """Decrypts a string using Fernet encryption."""
-    try:
-        return cipher.decrypt(encrypted_data.encode()).decode()
-    except Exception:
-        return "Decryption error: Invalid or corrupted data"
 
 def create_payment_intent(amount, currency="usd"):
     """Creates a Stripe Payment Intent for consolidating gift cards."""

--- a/backend/tests/test_consolidate.py
+++ b/backend/tests/test_consolidate.py
@@ -7,7 +7,7 @@ os.environ.setdefault("SECRET_KEY", "test")
 
 from app.__init__ import create_app, db, bcrypt
 from app.models import User, GiftCard, PlatformGiftCard
-from app.routes import encrypt_data
+from app.encryption_utils import encrypt_data
 
 
 def setup_app():


### PR DESCRIPTION
## Summary
- remove inline encryption logic from `routes.py`
- reuse shared functions from `encryption_utils`
- fix tests to import encryption helpers from the new location

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886b341b3b88325816b46a45358e1c0