### PR TITLE
Switch gift card API to tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,14 +196,14 @@ You can add physical or imported gift cards to a user's account using the
 POST /api/gift-cards
 {
   "user_id": 1,
-  "card_number": "123456789012",
+  "card_token": "tok_123456",
   "balance": 50,
   "expiry_date": "2099-12-31",
   "source": "physical_card"  # or "imported_card"
 }
 ```
 
-The API validates the card number format and ensures the expiry date is in the
+The API accepts a PSP-issued card token and ensures the expiry date is in the
 future before storing the card.
 
 ## Learn more

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -24,7 +24,7 @@ class GiftCard(db.Model):
     __tablename__ = 'gift_cards'
     card_id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     user_id = db.Column(db.Integer, db.ForeignKey('users.user_id'), nullable=False)
-    card_number = db.Column(db.String, unique=True, nullable=False)
+    token = db.Column(db.String, unique=True, nullable=False)
     balance = db.Column(db.Float, nullable=False)
     expiry_date = db.Column(db.DateTime, nullable=False)
     is_active = db.Column(db.Boolean, default=True)

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,7 +1,7 @@
 import os
 import re
 import stripe
-from .encryption_utils import encrypt_data, decrypt_data
+from .encryption_utils import encrypt_data
 from flask import Blueprint, request, jsonify
 from flask_limiter.errors import RateLimitExceeded
 from flask_login import login_user, logout_user, current_user, login_required
@@ -138,7 +138,7 @@ def get_gift_cards():
     for card in cards:
         result.append({
             "card_id": card.card_id,
-            "card_number": decrypt_data(card.card_number),
+            "card_token": card.token,
             "balance": card.balance,
             "expiry_date": card.expiry_date.isoformat()
             if isinstance(card.expiry_date, datetime)
@@ -159,35 +159,33 @@ def add_gift_card():
         user_id = int(user_id)
     except (TypeError, ValueError):
         return jsonify({"error": "Invalid user_id"}), 400
-    card_number = data.get("card_number")
+    card_token = data.get("card_token")
     balance = data.get("balance")
     expiry = data.get("expiry_date")
     source = data.get("source", "physical_card")
 
-    if not all([user_id, card_number, balance, expiry]):
+    if not all([user_id, card_token, balance, expiry]):
         return jsonify({"error": "Missing required fields"}), 400
 
-    error = validate_card_details(card_number, expiry)
-    if error:
-        return jsonify({"error": error}), 400
+    try:
+        exp_dt = datetime.strptime(expiry, "%Y-%m-%d")
+    except ValueError:
+        return jsonify({"error": "Invalid expiry date format"}), 400
+    if exp_dt.date() < datetime.utcnow().date():
+        return jsonify({"error": "Card already expired"}), 400
 
     try:
         balance = float(balance)
     except (TypeError, ValueError):
         return jsonify({"error": "Invalid balance"}), 400
 
-    exp_dt = datetime.strptime(expiry, "%Y-%m-%d")
-
-    existing = GiftCard.query.filter_by(user_id=user_id).all()
-    for card in existing:
-        if decrypt_data(card.card_number) == card_number:
-            return jsonify({"error": "Card already exists"}), 409
-
-    encrypted_number = encrypt_data(card_number)
+    existing = GiftCard.query.filter_by(user_id=user_id, token=card_token).first()
+    if existing:
+        return jsonify({"error": "Card already exists"}), 409
 
     new_card = GiftCard(
         user_id=user_id,
-        card_number=encrypted_number,
+        token=card_token,
         balance=balance,
         expiry_date=exp_dt,
         source=source,

--- a/backend/migrations/versions/0002_token_column.py
+++ b/backend/migrations/versions/0002_token_column.py
@@ -1,0 +1,23 @@
+"""add token column and remove card_number"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0002'
+down_revision = '0001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('gift_cards', sa.Column('token', sa.String(), nullable=True))
+    op.drop_column('gift_cards', 'card_number')
+    op.alter_column('gift_cards', 'token', nullable=False)
+    op.create_unique_constraint('uq_gift_cards_token', 'gift_cards', ['token'])
+
+
+def downgrade():
+    op.add_column('gift_cards', sa.Column('card_number', sa.String(), nullable=True))
+    op.drop_constraint('uq_gift_cards_token', 'gift_cards', type_='unique')
+    op.drop_column('gift_cards', 'token')
+    op.alter_column('gift_cards', 'card_number', nullable=False)
+    op.create_unique_constraint('uq_gift_cards_card_number', 'gift_cards', ['card_number'])

--- a/backend/tests/test_cards.py
+++ b/backend/tests/test_cards.py
@@ -33,7 +33,7 @@ def test_add_gift_card_success():
 
     resp = client.post('/api/gift-cards', json={
         'user_id': user_id,
-        'card_number': '123456789012',
+        'card_token': 'tok_123456',
         'balance': 25,
         'expiry_date': '2099-01-01',
         'source': 'physical_card'
@@ -46,6 +46,7 @@ def test_add_gift_card_success():
         cards = GiftCard.query.filter_by(user_id=user_id).all()
         assert len(cards) == 1
         assert cards[0].balance == 25
+        assert cards[0].token == 'tok_123456'
 
 
 def test_add_gift_card_expired():
@@ -56,7 +57,7 @@ def test_add_gift_card_expired():
 
     resp = client.post('/api/gift-cards', json={
         'user_id': user_id,
-        'card_number': '123456789012',
+        'card_token': 'tok_expired',
         'balance': 10,
         'expiry_date': '2000-01-01'
     })

--- a/backend/tests/test_consolidate.py
+++ b/backend/tests/test_consolidate.py
@@ -7,7 +7,6 @@ os.environ.setdefault("SECRET_KEY", "test")
 
 from app.__init__ import create_app, db, bcrypt
 from app.models import User, GiftCard, PlatformGiftCard
-from app.encryption_utils import encrypt_data
 
 
 def setup_app():
@@ -23,10 +22,10 @@ def create_user_with_cards(app):
         user = User(name='U', email='u@example.com', password_hash=pw)
         db.session.add(user)
         db.session.commit()
-        gc1 = GiftCard(user_id=user.user_id, card_number=encrypt_data('111111111111'),
+        gc1 = GiftCard(user_id=user.user_id, token='tok_gc1',
                        balance=10, expiry_date=datetime(2099,1,1), is_active=True,
                        source='physical_card')
-        gc2 = GiftCard(user_id=user.user_id, card_number=encrypt_data('222222222222'),
+        gc2 = GiftCard(user_id=user.user_id, token='tok_gc2',
                        balance=20, expiry_date=datetime(2099,1,1), is_active=True,
                        source='physical_card')
         db.session.add_all([gc1, gc2])

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -35,7 +35,7 @@ def test_unhandled_exception_returns_500(mocker):
 
     with app.app_context():
         from datetime import datetime
-        db.session.add(GiftCard(user_id=user_id, card_number='123', balance=10, expiry_date=datetime(2099,1,1), source='physical_card'))
+        db.session.add(GiftCard(user_id=user_id, token='tok_test', balance=10, expiry_date=datetime(2099,1,1), source='physical_card'))
         db.session.commit()
 
     mocker.patch('app.routes.stripe.PaymentIntent.create', side_effect=Exception('boom'))

--- a/compliance_report.json
+++ b/compliance_report.json
@@ -7,13 +7,13 @@
       "details": [
         {
           "file": "README.md",
-          "snippet": "  \"card_number\": \"123456789012\"",
-          "comment": "Documentation shows raw card numbers being sent to the backend via the gift card API."
+          "snippet": "  \"card_token\": \"tok_123456\"",
+          "comment": "Documentation now shows a PSP token being sent to the backend via the gift card API."
         },
         {
           "file": "backend/app/routes.py",
-          "snippet": "card_number = data.get(\"card_number\")",
-          "comment": "Backend route expects plain card numbers instead of PSP tokens."
+          "snippet": "card_token = data.get(\"card_token\")",
+          "comment": "Backend route now expects a PSP token instead of a raw card number."
         }
       ]
     },
@@ -54,7 +54,7 @@
         {
           "file": "backend/app/models.py",
           "snippet": "class GiftCard(db.Model):",
-          "comment": "Database stores card_number, balance and other financial data."
+          "comment": "Database stores a PSP token, balance and other financial data."
         },
         {
           "file": "backend/app/models.py",

--- a/frontend/HomeScreen.js
+++ b/frontend/HomeScreen.js
@@ -29,7 +29,7 @@ const HomeScreen = ({ navigation }) => {
         keyExtractor={(item) => item.card_id.toString()}
         renderItem={({ item }) => (
           <View style={[styles.cardItem, {backgroundColor: theme === "light" ? "#fff" : "#1e1e1e"}] }>
-            <ThemedText>Card Number: {item.card_number}</ThemedText>
+            <ThemedText>Token: {item.card_token}</ThemedText>
             <ThemedText>Balance: ${item.balance.toFixed(2)}</ThemedText>
           </View>
         )}


### PR DESCRIPTION
## Summary
- store PSP token instead of card number
- update `/gift-cards` routes for token usage
- adjust frontend and docs for token field
- add Alembic migration for new column
- update tests for token-based workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886b9a2c9448325917c88032e1bee12