### PR TITLE
Add split-tender purchase support

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -290,17 +290,23 @@ def link_bank_account():
 @api_bp.route("/purchase", methods=["POST"])
 @login_required
 def make_purchase():
-    """Charge a user's consolidated balance toward a purchase."""
+    """Charge a user's consolidated balance toward a purchase.
+
+    Supports split tender transactions by charging the platform gift card first
+    and the remainder to an additional payment token if provided.
+    """
+
     data = request.get_json() or {}
     user_id = data.get("user_id")
     amount = data.get("amount")
+    payment_token = data.get("payment_token")
 
     try:
         user_id = int(user_id)
     except (TypeError, ValueError):
         return jsonify({"error": "Invalid user_id"}), 400
 
-    if not all([user_id, amount]):
+    if user_id is None or amount is None:
         return jsonify({"error": "Missing required fields"}), 400
 
     try:
@@ -309,30 +315,48 @@ def make_purchase():
         return jsonify({"error": "Invalid amount"}), 400
 
     platform_card = PlatformGiftCard.query.filter_by(user_id=user_id).first()
-    if not platform_card or platform_card.balance < amount:
+    if not platform_card:
         return jsonify({"error": "Insufficient balance"}), 400
 
-    stripe_payment_id = None
-    if platform_card.stripe_card_id:
+    gift_amount = min(platform_card.balance, amount)
+    card_amount = amount - gift_amount
+
+    stripe_ids = []
+
+    if gift_amount > 0 and platform_card.stripe_card_id:
         try:
             intent = stripe.PaymentIntent.create(
-                amount=int(amount * 100),
+                amount=int(gift_amount * 100),
                 currency="usd",
                 payment_method=platform_card.stripe_card_id,
                 confirm=True,
             )
-            stripe_payment_id = intent.id
+            stripe_ids.append(intent.id)
         except stripe.error.StripeError as e:
             return jsonify({"error": str(e)}), 400
 
-    platform_card.balance -= amount
+    if card_amount > 0:
+        if not payment_token:
+            return jsonify({"error": "Insufficient balance"}), 400
+        try:
+            intent = stripe.PaymentIntent.create(
+                amount=int(card_amount * 100),
+                currency="usd",
+                payment_method=payment_token,
+                confirm=True,
+            )
+            stripe_ids.append(intent.id)
+        except stripe.error.StripeError as e:
+            return jsonify({"error": str(e)}), 400
+
+    platform_card.balance -= gift_amount
 
     transaction = Transaction(
         user_id=user_id,
         transaction_type="Purchase",
         amount=amount,
         details_encrypted=encrypt_data("Platform card purchase"),
-        stripe_payment_id=stripe_payment_id,
+        stripe_payment_id=",".join(stripe_ids) if stripe_ids else None,
     )
     db.session.add(transaction)
     db.session.commit()

--- a/backend/tests/test_purchase.py
+++ b/backend/tests/test_purchase.py
@@ -37,7 +37,7 @@ def test_purchase_success(mocker):
 
     mocker.patch("app.routes.stripe.PaymentIntent.create", return_value=type('obj', (object,), {'id': 'pi_789'})())
 
-    resp = client.post('/api/purchase', json={'user_id': user_id, 'amount': 15})
+    resp = client.post('/api/purchase', json={'user_id': user_id, 'amount': 15, 'payment_token': 'pm_card'})
     assert resp.status_code == 200
     data = resp.get_json()
     assert data['remaining_balance'] == 5
@@ -77,5 +77,37 @@ def test_purchase_requires_login():
         db.session.commit()
     resp = client.post('/api/purchase', json={'user_id': user_id, 'amount': 3})
     assert resp.status_code == 302
+
+
+def test_purchase_split_tender(mocker):
+    app = setup_app()
+    user_id = create_user(app)
+    client = app.test_client()
+    client.post('/api/login', json={'email': 'u@example.com', 'password': 'pw'})
+
+    with app.app_context():
+        card = PlatformGiftCard(user_id=user_id, balance=5, stripe_card_id="pm_123")
+        db.session.add(card)
+        db.session.commit()
+
+    mocker.patch(
+        "app.routes.stripe.PaymentIntent.create",
+        side_effect=[type('obj', (object,), {'id': 'pi_gc'})(), type('obj', (object,), {'id': 'pi_card'})()]
+    )
+
+    resp = client.post(
+        '/api/purchase',
+        json={'user_id': user_id, 'amount': 10, 'payment_token': 'pm_card'}
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['remaining_balance'] == 0
+
+    with app.app_context():
+        platform = PlatformGiftCard.query.filter_by(user_id=user_id).first()
+        assert platform.balance == 0
+        txns = Transaction.query.filter_by(user_id=user_id).all()
+        assert len(txns) == 1
+        assert txns[0].stripe_payment_id == 'pi_gc,pi_card'
 
 

--- a/frontend/PurchaseScreen.js
+++ b/frontend/PurchaseScreen.js
@@ -1,6 +1,7 @@
 import React, { useState, useContext } from "react";
 import { View, TextInput, Button, StyleSheet } from "react-native";
 import { makePurchase } from "./api";
+import { getItem } from "./SecureStore";
 import { ThemedText } from "./ThemedText";
 import { useColorScheme } from "./hooks/useColorScheme";
 import { Colors } from "./constants/Colors";
@@ -15,7 +16,12 @@ const PurchaseScreen = () => {
 
   const handlePurchase = async () => {
     if (!user) return;
-    const result = await makePurchase(user.user_id, parseFloat(amount));
+    const token = await getItem("last_payment_method");
+    const result = await makePurchase(
+      user.user_id,
+      parseFloat(amount),
+      token || undefined
+    );
     if (result?.remaining_balance !== undefined) {
       setMessage(`Remaining balance: $${result.remaining_balance}`);
     } else if (result?.error) {

--- a/frontend/api.js
+++ b/frontend/api.js
@@ -47,12 +47,16 @@ export const linkBankAccount = async (userId, bankToken) => {
 };
 
 
-export const makePurchase = async (userId, amount) => {
+export const makePurchase = async (userId, amount, paymentToken) => {
   try {
+    const body = { user_id: userId, amount };
+    if (paymentToken) {
+      body.payment_token = paymentToken;
+    }
     const response = await fetch(`${API_URL}/purchase`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ user_id: userId, amount }),
+      body: JSON.stringify(body),
       credentials: 'include',
     });
     return await response.json();

--- a/frontend/tests/api.test.js
+++ b/frontend/tests/api.test.js
@@ -41,11 +41,11 @@ test('linkBankAccount posts data', async () => {
 
 test('makePurchase posts data', async () => {
   fetch.mockResolvedValue({json: () => Promise.resolve({remaining_balance:5})});
-  const data = await makePurchase(1, 5);
+  const data = await makePurchase(1, 5, 'pm_tok');
   expect(fetch).toHaveBeenCalledWith('http://your-backend-url/api/purchase', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ user_id: 1, amount: 5 }),
+    body: JSON.stringify({ user_id: 1, amount: 5, payment_token: 'pm_tok' }),
     credentials: 'include',
   });
   expect(data).toEqual({remaining_balance:5});

--- a/frontend/tests/bankFlows.test.js
+++ b/frontend/tests/bankFlows.test.js
@@ -57,6 +57,8 @@ describe('banking flows', () => {
 
   test('PurchaseScreen makes purchase and shows remaining balance', async () => {
     makePurchase.mockResolvedValue({ remaining_balance: 5 });
+    const { getItem } = require('../SecureStore');
+    getItem.mockResolvedValue('pm_tok');
     let tree;
     await act(async () => {
       tree = renderer.create(
@@ -74,7 +76,7 @@ describe('banking flows', () => {
     await act(async () => {
       button.props.onPress();
     });
-    expect(makePurchase).toHaveBeenCalledWith(1, 5);
+    expect(makePurchase).toHaveBeenCalledWith(1, 5, 'pm_tok');
     const text = root.findAllByType(require('react-native').Text).find(t => t.props.children === 'Remaining balance: $5');
     expect(text).toBeTruthy();
   });


### PR DESCRIPTION
## Summary
- support split-tender logic in `make_purchase`
- include payment token in purchase API calls
- load last payment method on purchase screen
- update API and UI tests
- add backend test for split-tender

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q backend/tests`
- `npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886c6fbe6e083258e451b7f5e546eef