### PR TITLE
Drop sensitive details column

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -47,7 +47,6 @@ class Transaction(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey('users.user_id'), nullable=False)
     transaction_type = db.Column(db.String, nullable=False)  # Deposit, Transfer, Consolidation
     amount = db.Column(db.Float, nullable=False)
-    details_encrypted = db.Column(db.String, nullable=False)
     stripe_payment_id = db.Column(db.String, unique=True, nullable=True)  # Stripe Payment Intent ID
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
 

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,7 +1,6 @@
 import os
 import re
 import stripe
-from .encryption_utils import encrypt_data
 from flask import Blueprint, request, jsonify
 from flask_limiter.errors import RateLimitExceeded
 from flask_login import login_user, logout_user, current_user, login_required
@@ -355,7 +354,6 @@ def make_purchase():
         user_id=user_id,
         transaction_type="Purchase",
         amount=amount,
-        details_encrypted=encrypt_data("Platform card purchase"),
         stripe_payment_id=",".join(stripe_ids) if stripe_ids else None,
     )
     db.session.add(transaction)

--- a/backend/migrations/versions/0003_remove_details_encrypted.py
+++ b/backend/migrations/versions/0003_remove_details_encrypted.py
@@ -1,0 +1,16 @@
+"""remove sensitive transaction details"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0003'
+down_revision = '0002'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column('transactions', 'details_encrypted')
+
+
+def downgrade():
+    op.add_column('transactions', sa.Column('details_encrypted', sa.String(), nullable=False))


### PR DESCRIPTION
## Summary
- remove `details_encrypted` from Transaction model
- drop column via alembic migration
- update purchase route to stop saving encrypted details

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886c9b31f708325bd0ec6600db999be