### PR TITLE
Implement basic AML transaction monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,3 +314,10 @@ the backend executable.
 
 For details on how user data is handled see [PRIVACY_POLICY.md](./PRIVACY_POLICY.md). If a security incident occurs refer to our [BREACH_RESPONSE_PLAN.md](./BREACH_RESPONSE_PLAN.md).
 The [compliance](./compliance) directory contains the current SAQ A Questionnaire and Attestation of Compliance PDFs, version-controlled for audit purposes.
+
+### AML and transaction monitoring
+
+The backend logs every purchase to the `transactions` table via `app/aml.py`.
+Transactions over `AML_THRESHOLD` (default AUD 10,000) automatically generate a
+suspicious matter report entry in the AML log for review. This simple monitoring
+framework aligns with AUSTRAC guidance for ongoing customer due diligence.

--- a/backend/app/aml.py
+++ b/backend/app/aml.py
@@ -1,0 +1,42 @@
+import logging
+import os
+from datetime import datetime
+
+from .models import db, Transaction
+
+AML_THRESHOLD = float(os.getenv("AML_THRESHOLD", "10000"))
+
+
+def log_transaction(user_id: int, amount: float, transaction_type: str, stripe_payment_id: str | None = None) -> Transaction:
+    """Persist the transaction and trigger monitoring checks."""
+    txn = Transaction(
+        user_id=user_id,
+        amount=amount,
+        transaction_type=transaction_type,
+        stripe_payment_id=stripe_payment_id,
+        timestamp=datetime.utcnow(),
+    )
+    db.session.add(txn)
+    db.session.commit()
+
+    if amount >= AML_THRESHOLD:
+        report_suspicious_activity(txn)
+    return txn
+
+
+def report_suspicious_activity(txn: Transaction) -> None:
+    """Log a suspicious matter report entry.
+
+    In production this would submit an SMR to AUSTRAC. Here we simply log a
+    warning for compliance review.
+    """
+    logger = logging.getLogger("aml")
+    logger.warning(
+        "Suspicious transaction detected",
+        extra={
+            "transaction_id": txn.transaction_id,
+            "user_id": txn.user_id,
+            "amount": txn.amount,
+            "timestamp": txn.timestamp.isoformat(),
+        },
+    )

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -14,6 +14,7 @@ class User(db.Model, UserMixin):
     gift_cards = db.relationship("GiftCard", back_populates="user")
     platform_cards = db.relationship("PlatformGiftCard", back_populates="user")
     bank_accounts = db.relationship("BankAccount", back_populates="user")
+    transactions = db.relationship("Transaction", back_populates="user")
 
     def get_id(self):
         """Return the user identifier for Flask-Login sessions."""
@@ -48,3 +49,17 @@ class BankAccount(db.Model):
     last4 = db.Column(db.String, nullable=True)
 
     user = db.relationship("User", back_populates="bank_accounts")
+
+
+class Transaction(db.Model):
+    """Record of payment transactions for AML monitoring."""
+    __tablename__ = 'transactions'
+
+    transaction_id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('users.user_id'), nullable=False)
+    transaction_type = db.Column(db.String, nullable=False)
+    amount = db.Column(db.Float, nullable=False)
+    stripe_payment_id = db.Column(db.String, unique=True, nullable=True)
+    timestamp = db.Column(db.DateTime, nullable=True, default=datetime.utcnow)
+
+    user = db.relationship("User", back_populates="transactions")

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -5,6 +5,7 @@ from flask import Blueprint, request, jsonify, current_app
 from flask_limiter.errors import RateLimitExceeded
 from flask_login import login_user, logout_user, current_user, login_required
 from .__init__ import bcrypt, csrf
+from .aml import log_transaction
 from datetime import datetime
 from .config import Config
 
@@ -272,5 +273,7 @@ def make_purchase():
     current_app.logger.info(
         "purchase", extra={"user_id": user_id, "stripe_payment_id": stripe_id, "timestamp": datetime.utcnow().isoformat()}
     )
+
+    log_transaction(user_id=user_id, amount=amount, transaction_type="purchase", stripe_payment_id=stripe_id)
 
     return jsonify({"message": "purchase successful"})

--- a/backend/tests/test_aml.py
+++ b/backend/tests/test_aml.py
@@ -1,0 +1,44 @@
+import os
+
+os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test")
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("AML_THRESHOLD", "5000")
+
+from app.__init__ import create_app, db, bcrypt
+from app.models import User
+from app import aml
+
+
+def setup_app():
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def create_user(app):
+    with app.app_context():
+        pw = bcrypt.generate_password_hash("pw").decode("utf-8")
+        user = User(name="U", email="u@example.com", password_hash=pw)
+        db.session.add(user)
+        db.session.commit()
+        return user.user_id
+
+
+def test_large_purchase_triggers_report(mocker):
+    app = setup_app()
+    user_id = create_user(app)
+    client = app.test_client()
+    client.post("/api/login", json={"email": "u@example.com", "password": "pw"})
+
+    spy = mocker.spy(aml, "report_suspicious_activity")
+
+    mocker.patch("app.routes.stripe.PaymentIntent.create", return_value=type("obj", (object,), {"id": "pi_lg"})())
+
+    resp = client.post(
+        "/api/purchase",
+        json={"user_id": user_id, "amount": 6000, "payment_token": "pm_card"},
+    )
+    assert resp.status_code == 200
+    assert spy.call_count == 1


### PR DESCRIPTION
## Summary
- add `Transaction` model and AML utilities
- log purchases for AML monitoring and flag high-value transactions
- extend tests to cover AML behaviour
- document AML monitoring in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886e923b6988325a14e2cbe3b677731