### PR TITLE
Implement account deletion endpoint

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -9,7 +9,14 @@ from .aml import log_transaction
 from datetime import datetime
 from .config import Config
 
-from .models import db, GiftCard, PlatformGiftCard, User, BankAccount
+from .models import (
+    db,
+    GiftCard,
+    PlatformGiftCard,
+    User,
+    BankAccount,
+    Transaction,
+)
 
 STRIPE_SECRET_KEY = os.getenv("STRIPE_SECRET_KEY", Config.STRIPE_SECRET_KEY)
 stripe.api_key = STRIPE_SECRET_KEY
@@ -277,3 +284,24 @@ def make_purchase():
     log_transaction(user_id=user_id, amount=amount, transaction_type="purchase", stripe_payment_id=stripe_id)
 
     return jsonify({"message": "purchase successful"})
+
+
+@api_bp.route("/users/<int:user_id>", methods=["DELETE"])
+@login_required
+def delete_account(user_id):
+    """Delete the authenticated user's account and related data."""
+    if user_id != current_user.user_id:
+        return jsonify({"error": "forbidden"}), 403
+
+    user = db.session.get(User, user_id)
+    if not user:
+        return jsonify({"error": "User not found"}), 404
+
+    GiftCard.query.filter_by(user_id=user_id).delete()
+    PlatformGiftCard.query.filter_by(user_id=user_id).delete()
+    BankAccount.query.filter_by(user_id=user_id).delete()
+    Transaction.query.filter_by(user_id=user_id).delete()
+    db.session.delete(user)
+    db.session.commit()
+    logout_user()
+    return jsonify({"message": "account deleted"})

--- a/backend/tests/test_account_deletion.py
+++ b/backend/tests/test_account_deletion.py
@@ -1,0 +1,74 @@
+import os
+
+os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test")
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("SECRET_KEY", "test")
+
+from app.__init__ import create_app, db, bcrypt
+from datetime import datetime
+from app.models import User, GiftCard
+
+
+def setup_app():
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def create_user(app):
+    with app.app_context():
+        pw = bcrypt.generate_password_hash("pw").decode("utf-8")
+        user = User(name="U", email="u@example.com", password_hash=pw)
+        db.session.add(user)
+        db.session.commit()
+        card = GiftCard(
+            user_id=user.user_id,
+            token="tok",
+            expiry_date=datetime(2099, 1, 1),
+            source="physical",
+        )
+        db.session.add(card)
+        db.session.commit()
+        return user.user_id
+
+
+def test_delete_account():
+    app = setup_app()
+    user_id = create_user(app)
+    client = app.test_client()
+    client.post("/api/login", json={"email": "u@example.com", "password": "pw"})
+
+    resp = client.delete(f"/api/users/{user_id}")
+    assert resp.status_code == 200
+    assert resp.get_json()["message"] == "account deleted"
+
+    with app.app_context():
+        assert db.session.get(User, user_id) is None
+        assert GiftCard.query.filter_by(user_id=user_id).count() == 0
+
+
+def test_delete_account_wrong_user():
+    app = setup_app()
+    user_id = create_user(app)
+    with app.app_context():
+        pw = bcrypt.generate_password_hash("pw2").decode("utf-8")
+        other = User(name="O", email="o@example.com", password_hash=pw)
+        db.session.add(other)
+        db.session.commit()
+        other_id = other.user_id
+    client = app.test_client()
+    client.post("/api/login", json={"email": "o@example.com", "password": "pw2"})
+    resp = client.delete(f"/api/users/{user_id}")
+    assert resp.status_code == 403
+    with app.app_context():
+        assert db.session.get(User, user_id) is not None
+        assert db.session.get(User, other_id) is not None
+
+
+def test_delete_requires_login():
+    app = setup_app()
+    user_id = create_user(app)
+    client = app.test_client()
+    resp = client.delete(f"/api/users/{user_id}")
+    assert resp.status_code == 302

--- a/frontend/api.js
+++ b/frontend/api.js
@@ -113,3 +113,16 @@ export const sessionInfo = async () => {
     return null;
   }
 };
+
+export const deleteAccount = async (userId) => {
+  try {
+    const res = await fetch(`${API_URL}/users/${userId}`, {
+      method: 'DELETE',
+      credentials: 'include',
+    });
+    return await res.json();
+  } catch (error) {
+    console.error('Error deleting account:', error);
+    return null;
+  }
+};

--- a/frontend/tests/api.test.js
+++ b/frontend/tests/api.test.js
@@ -1,5 +1,5 @@
 process.env.BACKEND_URL = 'http://your-backend-url';
-const {fetchGiftCards, consolidateGiftCards, linkBankAccount, makePurchase} = require('../api');
+const {fetchGiftCards, consolidateGiftCards, linkBankAccount, makePurchase, deleteAccount} = require('../api');
 
 global.fetch = jest.fn();
 
@@ -49,4 +49,14 @@ test('makePurchase posts data', async () => {
     credentials: 'include',
   });
   expect(data).toEqual({message:'purchase successful'});
+});
+
+test('deleteAccount sends delete', async () => {
+  fetch.mockResolvedValue({json: () => Promise.resolve({message:'account deleted'})});
+  const data = await deleteAccount(3);
+  expect(fetch).toHaveBeenCalledWith('http://your-backend-url/api/users/3', {
+    method: 'DELETE',
+    credentials: 'include',
+  });
+  expect(data).toEqual({message:'account deleted'});
 });


### PR DESCRIPTION
## Summary
- add `/users/<user_id>` DELETE endpoint for removing accounts
- cover account deletion in backend tests
- support account deletion in frontend API and tests

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6886fd0872548325beadf30f02a4fd9b