### PR TITLE
Add persistent KYC model with Veriff integration

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -32,3 +32,7 @@ class Config:
 
     # Global rate limit for the API, used by Flask-Limiter
     RATE_LIMIT = os.environ.get('RATE_LIMIT', '100/hour')
+    # Veriff configuration
+    VERIFF_API_KEY = os.environ.get("VERIFF_API_KEY")
+    VERIFF_BASE_URL = os.environ.get("VERIFF_BASE_URL", "https://api.veriff.me/v1")
+

--- a/backend/app/kyc.py
+++ b/backend/app/kyc.py
@@ -1,22 +1,26 @@
 import logging
 from datetime import datetime, timedelta
 
+from .models import db, UserProfile as ProfileModel, VerificationAuditLog
+from .veriff_service import create_verification_session
+
 MAX_DAILY_TXN_LIMIT = 1000  # AUD
 MAX_SINGLE_TXN_LIMIT = 300  # AUD soft flag threshold
 MAX_BALANCE_LIMIT = 750  # AUD soft warning before hard KYC at 1000
 
 
 class UserProfile:
-    """Simple in-memory profile tracking AML/KYC status."""
+    """Ephemeral profile that mirrors persisted verification data."""
 
-    def __init__(self, user_id: int):
+    def __init__(self, user_id: int, db_profile: ProfileModel):
         self.user_id = user_id
-        self.kyc_status = "not_verified"  # can be "not_verified", "pending", "verified"
+        self.db_profile = db_profile
+        self.kyc_status = db_profile.verification_status
         self.daily_total = 0.0
         self.weekly_total = 0.0
         self.card_balances: list[tuple[int, float]] = []
         self.txn_log: list[tuple[float, str, list, datetime]] = []
-        self.flagged = False
+        self.flagged = db_profile.flagged
         self._day = datetime.utcnow().date()
         self._week_start = self._day - timedelta(days=self._day.weekday())
 
@@ -25,10 +29,19 @@ _profiles: dict[int, UserProfile] = {}
 
 
 def get_user_profile(user_id: int) -> UserProfile:
+    db_profile = db.session.get(ProfileModel, user_id)
+    if not db_profile:
+        db_profile = ProfileModel(user_id=user_id)
+        db.session.add(db_profile)
+        db.session.commit()
     profile = _profiles.get(user_id)
     if not profile:
-        profile = UserProfile(user_id)
+        profile = UserProfile(user_id, db_profile)
         _profiles[user_id] = profile
+    else:
+        profile.db_profile = db_profile
+        profile.kyc_status = db_profile.verification_status
+        profile.flagged = db_profile.flagged
     return profile
 
 
@@ -67,6 +80,9 @@ def process_transaction(user: UserProfile, amount: float, merchant_id: str, sour
 def trigger_kyc(user: UserProfile, reason: str):
     if user.kyc_status != "verified":
         user.kyc_status = "pending"
+        user.db_profile.verification_status = "pending"
+        db.session.add(VerificationAuditLog(user_id=user.user_id, action="kyc_triggered", details=reason))
+        db.session.commit()
         send_kyc_request(user, reason)
 
 
@@ -79,6 +95,9 @@ def detect_structuring(user: UserProfile) -> bool:
 
 def flag_suspicious(user: UserProfile, reason: str):
     user.flagged = True
+    user.db_profile.flagged = True
+    db.session.add(VerificationAuditLog(user_id=user.user_id, action="flagged", details=reason))
+    db.session.commit()
     submit_au_strac_smr(user, reason)
 
 
@@ -86,6 +105,13 @@ def flag_suspicious(user: UserProfile, reason: str):
 
 def send_kyc_request(user: UserProfile, reason: str) -> None:
     log(f"KYC request triggered for {user.user_id}: {reason}")
+    try:
+        session_id = create_verification_session(user.user_id)
+        user.db_profile.veriff_session_id = session_id
+        db.session.add(VerificationAuditLog(user_id=user.user_id, action="veriff_session", details=session_id))
+        db.session.commit()
+    except Exception as exc:
+        log(f"Veriff error for {user.user_id}: {exc}")
 
 
 def submit_au_strac_smr(user: UserProfile, reason: str) -> None:

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -63,3 +63,44 @@ class Transaction(db.Model):
     timestamp = db.Column(db.DateTime, nullable=True, default=datetime.utcnow)
 
     user = db.relationship("User", back_populates="transactions")
+
+class UserProfile(db.Model):
+    """Persistent profile for AML/KYC status."""
+    __tablename__ = 'user_profiles'
+    user_id = db.Column(db.Integer, db.ForeignKey('users.user_id'), primary_key=True)
+    verification_status = db.Column(db.String, nullable=False, default='not_verified')
+    veriff_session_id = db.Column(db.String, nullable=True)
+    flagged = db.Column(db.Boolean, default=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    user = db.relationship('User', backref=db.backref('profile', uselist=False))
+
+    # aliases for backward compatibility
+    @property
+    def kyc_status(self):
+        return self.verification_status
+
+    @kyc_status.setter
+    def kyc_status(self, value):
+        self.verification_status = value
+
+class IdentificationDocument(db.Model):
+    __tablename__ = 'identification_documents'
+    doc_id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user_profiles.user_id'), nullable=False)
+    doc_type = db.Column(db.String, nullable=False)
+    file_path = db.Column(db.String, nullable=False)
+    uploaded_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    profile = db.relationship('UserProfile', backref='documents')
+
+class VerificationAuditLog(db.Model):
+    __tablename__ = 'verification_audit_logs'
+    log_id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user_profiles.user_id'), nullable=False)
+    action = db.Column(db.String, nullable=False)
+    details = db.Column(db.String, nullable=True)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+
+    profile = db.relationship('UserProfile', backref='logs')

--- a/backend/app/veriff_service.py
+++ b/backend/app/veriff_service.py
@@ -1,0 +1,44 @@
+import os
+import requests
+from .config import Config
+
+VERIFF_API_KEY = os.getenv('VERIFF_API_KEY')
+VERIFF_BASE_URL = os.getenv('VERIFF_BASE_URL', 'https://api.veriff.me/v1')
+
+class VeriffError(Exception):
+    pass
+
+def create_verification_session(user_id: int) -> str:
+    """Create a Veriff session and return the session ID."""
+    if not VERIFF_API_KEY:
+        raise VeriffError('VERIFF_API_KEY not configured')
+    payload = {
+        'verification': {
+            'person': {'id': str(user_id)},
+            'document': {'type': 'passport'},
+        }
+    }
+    headers = {
+        'X-AUTH-CLIENT': VERIFF_API_KEY,
+        'Content-Type': 'application/json',
+    }
+    resp = requests.post(f'{VERIFF_BASE_URL}/sessions', json=payload, headers=headers, timeout=10)
+    if resp.status_code != 201:
+        raise VeriffError(f'Session creation failed: {resp.text}')
+    data = resp.json()
+    return data['verification']['id']
+
+
+def fetch_verification_status(session_id: str) -> str:
+    """Return Veriff session status."""
+    if not VERIFF_API_KEY:
+        raise VeriffError('VERIFF_API_KEY not configured')
+    headers = {
+        'X-AUTH-CLIENT': VERIFF_API_KEY,
+        'Content-Type': 'application/json',
+    }
+    resp = requests.get(f'{VERIFF_BASE_URL}/sessions/{session_id}', headers=headers, timeout=10)
+    if resp.status_code != 200:
+        raise VeriffError(f'Status fetch failed: {resp.text}')
+    data = resp.json()
+    return data['verification']['status']

--- a/backend/migrations/versions/0005_veriff_integration.py
+++ b/backend/migrations/versions/0005_veriff_integration.py
@@ -1,0 +1,42 @@
+"""add verification tables"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0005'
+down_revision = '0004'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'user_profiles',
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.user_id'), primary_key=True),
+        sa.Column('verification_status', sa.String(), nullable=False, server_default='not_verified'),
+        sa.Column('veriff_session_id', sa.String(), nullable=True),
+        sa.Column('flagged', sa.Boolean(), nullable=True, server_default=sa.text('false')),
+        sa.Column('created_at', sa.DateTime(), nullable=True, server_default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime(), nullable=True, server_default=sa.func.now()),
+    )
+    op.create_table(
+        'identification_documents',
+        sa.Column('doc_id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('user_profiles.user_id'), nullable=False),
+        sa.Column('doc_type', sa.String(), nullable=False),
+        sa.Column('file_path', sa.String(), nullable=False),
+        sa.Column('uploaded_at', sa.DateTime(), nullable=True, server_default=sa.func.now()),
+    )
+    op.create_table(
+        'verification_audit_logs',
+        sa.Column('log_id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('user_profiles.user_id'), nullable=False),
+        sa.Column('action', sa.String(), nullable=False),
+        sa.Column('details', sa.String(), nullable=True),
+        sa.Column('timestamp', sa.DateTime(), nullable=True, server_default=sa.func.now()),
+    )
+
+
+def downgrade():
+    op.drop_table('verification_audit_logs')
+    op.drop_table('identification_documents')
+    op.drop_table('user_profiles')

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,4 @@ pytest-mock
 Flask-Migrate
 alembic
 flask-limiter
+requests

--- a/backend/tests/test_kyc.py
+++ b/backend/tests/test_kyc.py
@@ -4,7 +4,7 @@ os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 os.environ.setdefault("SECRET_KEY", "test")
 
 from app.__init__ import create_app, db, bcrypt
-from app.models import User
+from app.models import User, UserProfile
 from app import aml, kyc
 
 
@@ -24,20 +24,25 @@ def create_user(app):
         return user.user_id
 
 
-def test_daily_limit_triggers_kyc():
+def test_daily_limit_triggers_kyc(mocker):
     app = setup_app()
     user_id = create_user(app)
+    mocker.patch("app.kyc.create_verification_session", return_value="sess")
     with app.app_context():
         for _ in range(4):
             aml.log_transaction(user_id, 250, "purchase")
         profile = kyc.get_user_profile(user_id)
         assert profile.kyc_status == "pending"
+        db_profile = UserProfile.query.get(user_id)
+        assert db_profile.verification_status == "pending"
 
 
-def test_single_large_transaction_flagged():
+def test_single_large_transaction_flagged(mocker):
     app = setup_app()
     user_id = create_user(app)
+    mocker.patch("app.kyc.create_verification_session", return_value="sess")
     with app.app_context():
         aml.log_transaction(user_id, 350, "purchase")
         profile = kyc.get_user_profile(user_id)
         assert profile.flagged is True
+        assert UserProfile.query.get(user_id).flagged is True


### PR DESCRIPTION
## Summary
- integrate Veriff identity verification service
- store KYC data in new persistent `user_profiles` table
- record identification documents and audit logs in new tables
- call Veriff when KYC is triggered and save session IDs
- extend tests to verify persistence

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887122d8b448325892dacab7e6a7375