### PR TITLE
Add compliance tables and export utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,3 +330,17 @@ beyond the single transaction threshold. The scheduler also alerts the
 compliance team when a user profile is flagged or remains in a pending KYC state
 for more than three days. Alerts are written to the `compliance` log for
 follow‑up.
+
+### Compliance record retention and export
+
+KYC records, Suspicious Matter Reports and AML log entries are stored for a
+minimum of seven years in the `kyc_records`, `suspicious_matter_reports` and
+`aml_logs` tables. Use the `export_compliance_records.py` utility in the
+`backend/app` directory to export CSV files for AUSTRAC audits:
+
+```bash
+python export_compliance_records.py --out-dir /tmp/exports
+```
+
+This will generate separate CSV files for each table containing all historical
+records.

--- a/backend/app/aml.py
+++ b/backend/app/aml.py
@@ -4,7 +4,12 @@ from datetime import datetime
 
 from .kyc import get_user_profile, process_transaction
 
-from .models import db, Transaction
+from .models import (
+    db,
+    Transaction,
+    SuspiciousMatterReportEntry,
+    AMLLogEntry,
+)
 
 AUSTRAC_API_URL = os.getenv("AUSTRAC_API_URL", "https://api.austrac.gov.au/smr/submit")
 APP_ENTITY_ID = os.getenv("APP_ENTITY_ID", "APP_ENTITY")
@@ -56,6 +61,17 @@ def log_transaction(user_id: int, amount: float, transaction_type: str, stripe_p
     db.session.add(txn)
     db.session.commit()
 
+    # persist AML log entry
+    db.session.add(
+        AMLLogEntry(
+            user_id=user_id,
+            action="transaction_logged",
+            details=f"{transaction_type}:{amount}",
+            timestamp=txn.timestamp,
+        )
+    )
+    db.session.commit()
+
     # Update KYC/AML monitoring profile
     try:
         profile = get_user_profile(user_id)
@@ -88,6 +104,21 @@ def report_suspicious_activity(txn: Transaction) -> None:
     try:
         report = build_suspicious_matter_report(txn)
         result = submit_suspicious_matter_report(report)
+        db.session.add(
+            SuspiciousMatterReportEntry(
+                user_id=txn.user_id,
+                transaction_id=txn.transaction_id,
+                report_json=str(report),
+            )
+        )
+        db.session.add(
+            AMLLogEntry(
+                user_id=txn.user_id,
+                action="smr_submitted",
+                details=str(report),
+            )
+        )
+        db.session.commit()
         logger.info("SMR processed: %s", result)
     except Exception as exc:
         logger.error("SMR handling failed: %s", exc)

--- a/backend/app/export_compliance_records.py
+++ b/backend/app/export_compliance_records.py
@@ -1,0 +1,40 @@
+import argparse
+import csv
+import os
+from datetime import datetime
+
+from . import create_app, db
+from .models import KYCRecord, SuspiciousMatterReportEntry, AMLLogEntry
+
+
+def export_table(session, model, path):
+    """Export a single SQLAlchemy model to CSV."""
+    records = session.query(model).all()
+    if not records:
+        return 0
+    columns = [c.name for c in model.__table__.columns]
+    with open(path, "w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(columns)
+        for rec in records:
+            writer.writerow([getattr(rec, c) for c in columns])
+    return len(records)
+
+
+def main(out_dir: str):
+    app = create_app()
+    with app.app_context():
+        os.makedirs(out_dir, exist_ok=True)
+        session = db.session
+        counts = {}
+        counts['kyc'] = export_table(session, KYCRecord, os.path.join(out_dir, 'kyc_records.csv'))
+        counts['smr'] = export_table(session, SuspiciousMatterReportEntry, os.path.join(out_dir, 'suspicious_matter_reports.csv'))
+        counts['aml'] = export_table(session, AMLLogEntry, os.path.join(out_dir, 'aml_logs.csv'))
+        print("Exported records:", counts)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Export compliance records to CSV files')
+    parser.add_argument('--out-dir', default='exports', help='Directory to write CSV files')
+    args = parser.parse_args()
+    main(args.out_dir)

--- a/backend/app/kyc.py
+++ b/backend/app/kyc.py
@@ -1,7 +1,13 @@
 import logging
 from datetime import datetime, timedelta
 
-from .models import db, UserProfile as ProfileModel, VerificationAuditLog
+from .models import (
+    db,
+    UserProfile as ProfileModel,
+    VerificationAuditLog,
+    KYCRecord,
+    AMLLogEntry,
+)
 from .veriff_service import create_verification_session
 
 MAX_DAILY_TXN_LIMIT = 1000  # AUD
@@ -84,6 +90,7 @@ def trigger_kyc(user: UserProfile, reason: str):
         db.session.add(VerificationAuditLog(user_id=user.user_id, action="kyc_triggered", details=reason))
         db.session.commit()
         send_kyc_request(user, reason)
+        store_kyc_information(user.user_id, "kyc_trigger", reason)
 
 
 def detect_structuring(user: UserProfile) -> bool:
@@ -98,6 +105,7 @@ def flag_suspicious(user: UserProfile, reason: str):
     user.db_profile.flagged = True
     db.session.add(VerificationAuditLog(user_id=user.user_id, action="flagged", details=reason))
     db.session.commit()
+    store_kyc_information(user.user_id, "flagged", reason)
     submit_au_strac_smr(user, reason)
 
 
@@ -116,6 +124,26 @@ def send_kyc_request(user: UserProfile, reason: str) -> None:
 
 def submit_au_strac_smr(user: UserProfile, reason: str) -> None:
     log(f"SMR submitted for {user.user_id}: {reason}")
+
+
+def store_kyc_information(user_id: int, info_type: str, info_data: str) -> None:
+    """Persist KYC data with a 7 year retention period."""
+    retention = datetime.utcnow() + timedelta(days=365 * 7)
+    record = KYCRecord(
+        user_id=user_id,
+        info_type=info_type,
+        info_data=info_data,
+        retention_until=retention,
+    )
+    db.session.add(record)
+    db.session.add(
+        AMLLogEntry(
+            user_id=user_id,
+            action="kyc_recorded",
+            details=info_type,
+        )
+    )
+    db.session.commit()
 
 
 def warn_user(user: UserProfile, message: str) -> None:

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -104,3 +104,38 @@ class VerificationAuditLog(db.Model):
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
 
     profile = db.relationship('UserProfile', backref='logs')
+
+class KYCRecord(db.Model):
+    """Detailed KYC information retained for compliance."""
+    __tablename__ = 'kyc_records'
+    record_id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('users.user_id'), nullable=False)
+    info_type = db.Column(db.String, nullable=False)
+    info_data = db.Column(db.String, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    retention_until = db.Column(db.DateTime, nullable=False)
+
+    user = db.relationship('User', backref='kyc_records')
+
+class SuspiciousMatterReportEntry(db.Model):
+    """Record of submitted Suspicious Matter Reports."""
+    __tablename__ = 'suspicious_matter_reports'
+    smr_id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('users.user_id'), nullable=False)
+    transaction_id = db.Column(db.Integer, db.ForeignKey('transactions.transaction_id'), nullable=True)
+    report_json = db.Column(db.String, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    user = db.relationship('User', backref='smr_entries')
+    transaction = db.relationship('Transaction')
+
+class AMLLogEntry(db.Model):
+    """Audit log for AML related events."""
+    __tablename__ = 'aml_logs'
+    log_id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('users.user_id'), nullable=True)
+    action = db.Column(db.String, nullable=False)
+    details = db.Column(db.String, nullable=True)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+
+    user = db.relationship('User', backref='aml_logs')

--- a/backend/migrations/versions/0006_compliance_records.py
+++ b/backend/migrations/versions/0006_compliance_records.py
@@ -1,0 +1,42 @@
+"""add kyc, smr and aml log tables"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0006'
+down_revision = '0005'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'kyc_records',
+        sa.Column('record_id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.user_id'), nullable=False),
+        sa.Column('info_type', sa.String(), nullable=False),
+        sa.Column('info_data', sa.String(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=True, server_default=sa.func.now()),
+        sa.Column('retention_until', sa.DateTime(), nullable=False),
+    )
+    op.create_table(
+        'suspicious_matter_reports',
+        sa.Column('smr_id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.user_id'), nullable=False),
+        sa.Column('transaction_id', sa.Integer(), sa.ForeignKey('transactions.transaction_id'), nullable=True),
+        sa.Column('report_json', sa.String(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=True, server_default=sa.func.now()),
+    )
+    op.create_table(
+        'aml_logs',
+        sa.Column('log_id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.user_id'), nullable=True),
+        sa.Column('action', sa.String(), nullable=False),
+        sa.Column('details', sa.String(), nullable=True),
+        sa.Column('timestamp', sa.DateTime(), nullable=True, server_default=sa.func.now()),
+    )
+
+
+def downgrade():
+    op.drop_table('aml_logs')
+    op.drop_table('suspicious_matter_reports')
+    op.drop_table('kyc_records')


### PR DESCRIPTION
## Summary
- add KYCRecord, SuspiciousMatterReportEntry and AMLLogEntry models
- log AML activities and Suspicious Matter Reports to new tables
- store KYC records when KYC is triggered or a user is flagged
- provide CSV export utility for AUSTRAC audits
- document compliance record retention and export usage
- include migration script

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887158c38a88325a13669211a937b90