### PR TITLE
Capture SMR reasons and deadlines

### DIFF
--- a/backend/app/aml.py
+++ b/backend/app/aml.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from .kyc import get_user_profile, process_transaction
 
@@ -16,10 +16,12 @@ APP_ENTITY_ID = os.getenv("APP_ENTITY_ID", "APP_ENTITY")
 ENABLE_LIVE_SUBMISSION = os.getenv("ENABLE_LIVE_SUBMISSION", "false").lower() == "true"
 LOCAL_SM_LOG_PATH = os.getenv("LOCAL_SM_LOG_PATH", "suspicious_reports.log")
 
+SMR_DEADLINE_HOURS = int(os.getenv("SMR_DEADLINE_HOURS", "72"))
+
 AML_THRESHOLD = float(os.getenv("AML_THRESHOLD", "10000"))
 
 
-def build_suspicious_matter_report(txn: Transaction) -> dict:
+def build_suspicious_matter_report(txn: Transaction, reason: str) -> dict:
     """Create the payload for a Suspicious Matter Report."""
     return {
         "reporting_entity_id": APP_ENTITY_ID,
@@ -28,11 +30,21 @@ def build_suspicious_matter_report(txn: Transaction) -> dict:
         "timestamp": txn.timestamp.isoformat(),
         "amount": txn.amount,
         "transaction_type": txn.transaction_type,
+        "reason": reason,
     }
 
 
+def manual_review(report: dict) -> None:
+    """Persist the report for manual compliance review."""
+    with open(LOCAL_SM_LOG_PATH, "a") as fh:
+        import json
+
+        json.dump(report, fh)
+        fh.write("\n")
+
+
 def submit_suspicious_matter_report(report: dict) -> str:
-    """Submit the report to AUSTRAC or save it locally."""
+    """Submit the report to AUSTRAC or queue for manual review."""
     if ENABLE_LIVE_SUBMISSION:
         import requests
 
@@ -41,12 +53,8 @@ def submit_suspicious_matter_report(report: dict) -> str:
             raise RuntimeError("AUSTRAC SMR submission failed")
         return "Submitted"
     else:
-        with open(LOCAL_SM_LOG_PATH, "a") as fh:
-            import json
-
-            json.dump(report, fh)
-            fh.write("\n")
-        return "Saved locally for compliance review"
+        manual_review(report)
+        return "Pending manual review"
 
 
 def log_transaction(user_id: int, amount: float, transaction_type: str, stripe_payment_id: str | None = None) -> Transaction:
@@ -80,11 +88,11 @@ def log_transaction(user_id: int, amount: float, transaction_type: str, stripe_p
         logging.getLogger("aml").error("KYC processing failed: %s", exc)
 
     if amount >= AML_THRESHOLD:
-        report_suspicious_activity(txn)
+        report_suspicious_activity(txn, reason="Amount exceeds threshold")
     return txn
 
 
-def report_suspicious_activity(txn: Transaction) -> None:
+def report_suspicious_activity(txn: Transaction, reason: str) -> None:
     """Log a suspicious matter report entry.
 
     In production this would submit an SMR to AUSTRAC. Here we simply log a
@@ -98,23 +106,68 @@ def report_suspicious_activity(txn: Transaction) -> None:
             "user_id": txn.user_id,
             "amount": txn.amount,
             "timestamp": txn.timestamp.isoformat(),
+            "reason": reason,
         },
     )
 
     try:
-        report = build_suspicious_matter_report(txn)
+        report = build_suspicious_matter_report(txn, reason)
+        required_by = txn.timestamp + timedelta(hours=SMR_DEADLINE_HOURS)
+        if datetime.utcnow() > required_by:
+            raise RuntimeError("SMR submission overdue")
         result = submit_suspicious_matter_report(report)
         db.session.add(
             SuspiciousMatterReportEntry(
                 user_id=txn.user_id,
                 transaction_id=txn.transaction_id,
                 report_json=str(report),
+                reason=reason,
+                required_by=required_by,
+                submitted_at=datetime.utcnow() if ENABLE_LIVE_SUBMISSION else None,
             )
         )
         db.session.add(
             AMLLogEntry(
                 user_id=txn.user_id,
-                action="smr_submitted",
+                action="smr_submitted" if ENABLE_LIVE_SUBMISSION else "smr_queued",
+                details=str(report),
+            )
+        )
+        db.session.commit()
+        logger.info("SMR processed: %s", result)
+    except Exception as exc:
+        logger.error("SMR handling failed: %s", exc)
+
+
+def report_user_suspicion(user_id: int, reason: str) -> None:
+    """Log a suspicious matter report not tied to a transaction."""
+    logger = logging.getLogger("aml")
+    now = datetime.utcnow()
+    report = {
+        "reporting_entity_id": APP_ENTITY_ID,
+        "user_id": user_id,
+        "timestamp": now.isoformat(),
+        "reason": reason,
+    }
+    required_by = now + timedelta(hours=SMR_DEADLINE_HOURS)
+    try:
+        if datetime.utcnow() > required_by:
+            raise RuntimeError("SMR submission overdue")
+        result = submit_suspicious_matter_report(report)
+        db.session.add(
+            SuspiciousMatterReportEntry(
+                user_id=user_id,
+                transaction_id=None,
+                report_json=str(report),
+                reason=reason,
+                required_by=required_by,
+                submitted_at=datetime.utcnow() if ENABLE_LIVE_SUBMISSION else None,
+            )
+        )
+        db.session.add(
+            AMLLogEntry(
+                user_id=user_id,
+                action="smr_submitted" if ENABLE_LIVE_SUBMISSION else "smr_queued",
                 details=str(report),
             )
         )

--- a/backend/app/kyc.py
+++ b/backend/app/kyc.py
@@ -123,7 +123,10 @@ def send_kyc_request(user: UserProfile, reason: str) -> None:
 
 
 def submit_au_strac_smr(user: UserProfile, reason: str) -> None:
+    from . import aml
+
     log(f"SMR submitted for {user.user_id}: {reason}")
+    aml.report_user_suspicion(user.user_id, reason)
 
 
 def store_kyc_information(user_id: int, info_type: str, info_data: str) -> None:

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -124,6 +124,9 @@ class SuspiciousMatterReportEntry(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey('users.user_id'), nullable=False)
     transaction_id = db.Column(db.Integer, db.ForeignKey('transactions.transaction_id'), nullable=True)
     report_json = db.Column(db.String, nullable=False)
+    reason = db.Column(db.String, nullable=True)
+    required_by = db.Column(db.DateTime, nullable=True)
+    submitted_at = db.Column(db.DateTime, nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
     user = db.relationship('User', backref='smr_entries')

--- a/backend/app/scheduled_tasks.py
+++ b/backend/app/scheduled_tasks.py
@@ -5,7 +5,8 @@ from datetime import datetime, timedelta
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.schedulers.base import STATE_STOPPED
 
-from .models import db, UserProfile, Transaction
+from .models import db, UserProfile, Transaction, SuspiciousMatterReportEntry
+from .aml import SMR_DEADLINE_HOURS
 from . import kyc
 
 scheduler = BackgroundScheduler()
@@ -61,6 +62,20 @@ def alert_flagged_profiles() -> None:
         alert_compliance(f"User {profile.user_id} flagged for review")
 
 
+def check_overdue_smrs() -> None:
+    """Ensure all SMRs are submitted before the deadline."""
+    now = datetime.utcnow()
+    overdue = SuspiciousMatterReportEntry.query.filter(
+        SuspiciousMatterReportEntry.submitted_at.is_(None),
+        SuspiciousMatterReportEntry.required_by < now,
+    ).all()
+    for entry in overdue:
+        alert_compliance(
+            f"SMR for user {entry.user_id} overdue by "
+            f"{(now - entry.required_by).total_seconds() / 3600:.1f}h"
+        )
+
+
 def init_scheduler(app):
     """Start background scheduler with compliance jobs."""
     global _atexit_registered
@@ -68,6 +83,7 @@ def init_scheduler(app):
         scheduler.add_job(review_transaction_patterns, "interval", days=1)
         scheduler.add_job(review_pending_kyc, "interval", hours=24)
         scheduler.add_job(alert_flagged_profiles, "interval", hours=24)
+        scheduler.add_job(check_overdue_smrs, "interval", hours=1)
         scheduler.start()
         if app.config.get("SCHEDULER_SHUTDOWN_AT_EXIT", True) and not _atexit_registered:
             import atexit

--- a/backend/tests/test_aml.py
+++ b/backend/tests/test_aml.py
@@ -38,6 +38,7 @@ def test_large_purchase_triggers_report(mocker, tmp_path):
     client.post("/api/login", json={"email": "u@example.com", "password": "pw"})
 
     spy = mocker.spy(aml, "report_suspicious_activity")
+    review_spy = mocker.spy(aml, "manual_review")
     post_mock = mocker.patch("requests.post")
 
     mocker.patch("app.routes.stripe.PaymentIntent.create", return_value=type("obj", (object,), {"id": "pi_lg"})())
@@ -49,5 +50,10 @@ def test_large_purchase_triggers_report(mocker, tmp_path):
     assert resp.status_code == 200
     assert spy.call_count == 1
     post_mock.assert_not_called()
+    review_spy.assert_called()
     with open(log_path) as f:
-        assert len(f.readlines()) == 1
+        lines = f.readlines()
+        assert len(lines) >= 1
+        import json
+        report = json.loads(lines[-1])
+        assert report["reason"] == "Amount exceeds threshold"


### PR DESCRIPTION
## Summary
- store suspicious matter report reason, submission deadline and timestamp
- ensure SMRs are queued for manual review when live submission is disabled
- enforce that SMRs are submitted before the deadline
- alert on overdue SMRs via scheduled task
- update AML tests for new manual review step

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688717c9d63083258d5c85b3e6cd872e