### PR TITLE
Add mobile login screen

### DIFF
--- a/mobile/LoginScreen.js
+++ b/mobile/LoginScreen.js
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { loginUser } from './api';
+
+const LoginScreen = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleLogin = async () => {
+    const res = await loginUser(email, password);
+    if (res?.error) {
+      setMessage(res.error);
+    } else {
+      setMessage(res.message || 'Login successful');
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Login</Text>
+      <TextInput
+        placeholder="Email"
+        value={email}
+        onChangeText={setEmail}
+        style={styles.input}
+      />
+      <TextInput
+        placeholder="Password"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+        style={styles.input}
+      />
+      <Button title="Login" onPress={handleLogin} />
+      {message ? <Text style={styles.message}>{message}</Text> : null}
+    </View>
+  );
+};
+
+export default LoginScreen;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    justifyContent: 'center',
+    backgroundColor: '#fff',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 20,
+    textAlign: 'center',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginVertical: 10,
+    borderRadius: 6,
+  },
+  message: {
+    marginTop: 20,
+    textAlign: 'center',
+  },
+});


### PR DESCRIPTION
## Summary
- add a LoginScreen component for the mobile app
- reuse the frontend login layout and call `loginUser`

## Testing
- `npm test --silent` in `frontend`
- `pytest -q` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68872b64aeb083258ba752ba653013e8