### PR TITLE
Add mobile screens for card management and payments

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -3,6 +3,9 @@ import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import LoginScreen from './LoginScreen';
 import HomeScreen from './HomeScreen';
+import GiftCardListScreen from './GiftCardListScreen';
+import BankLinkScreen from './BankLinkScreen';
+import PurchaseScreen from './PurchaseScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -12,6 +15,9 @@ export default function App() {
       <Stack.Navigator initialRouteName="Login">
         <Stack.Screen name="Login" component={LoginScreen} options={{ headerShown: false }} />
         <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="GiftCards" component={GiftCardListScreen} />
+        <Stack.Screen name="BankLink" component={BankLinkScreen} />
+        <Stack.Screen name="Purchase" component={PurchaseScreen} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/mobile/BankLinkScreen.js
+++ b/mobile/BankLinkScreen.js
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { linkBankAccount, sessionInfo } from './api';
+
+const BankLinkScreen = () => {
+  const [userId, setUserId] = useState(null);
+  const [bankToken, setBankToken] = useState('');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const loadSession = async () => {
+      const info = await sessionInfo();
+      if (info?.authenticated) {
+        setUserId(info.user_id);
+      }
+    };
+    loadSession();
+  }, []);
+
+  const handleLink = async () => {
+    if (!userId || !bankToken) return;
+    const res = await linkBankAccount(userId, bankToken);
+    if (res?.message) {
+      setMessage(res.message);
+    } else if (res?.error) {
+      setMessage(res.error);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Link Bank Account</Text>
+      <TextInput
+        placeholder="Bank token"
+        value={bankToken}
+        onChangeText={setBankToken}
+        style={styles.input}
+      />
+      <Button title="Link" onPress={handleLink} />
+      {message ? <Text style={styles.message}>{message}</Text> : null}
+    </View>
+  );
+};
+
+export default BankLinkScreen;
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 20, backgroundColor: '#fff' },
+  title: { fontSize: 20, marginBottom: 10, textAlign: 'center' },
+  input: { borderWidth: 1, borderColor: '#ccc', padding: 8, marginVertical: 10, borderRadius: 6 },
+  message: { marginTop: 20, textAlign: 'center' },
+});

--- a/mobile/GiftCardListScreen.js
+++ b/mobile/GiftCardListScreen.js
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList, Button, StyleSheet } from 'react-native';
+import { fetchGiftCards, consolidateGiftCards, sessionInfo } from './api';
+
+const GiftCardListScreen = () => {
+  const [userId, setUserId] = useState(null);
+  const [cards, setCards] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState('');
+
+  const loadCards = async (uid) => {
+    setLoading(true);
+    const data = await fetchGiftCards(uid);
+    setCards(Array.isArray(data) ? data : []);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    const loadSession = async () => {
+      const info = await sessionInfo();
+      if (info?.authenticated) {
+        setUserId(info.user_id);
+        loadCards(info.user_id);
+      }
+    };
+    loadSession();
+  }, []);
+
+  const handleConsolidate = async () => {
+    if (!userId) return;
+    const res = await consolidateGiftCards(userId);
+    if (res?.message) {
+      setMessage(res.message);
+      loadCards(userId);
+    } else if (res?.error) {
+      setMessage(res.error);
+    }
+  };
+
+  const renderItem = ({ item }) => (
+    <View style={styles.cardItem}>
+      <Text>Card ID: {item.card_id}</Text>
+      <Text>Token: {item.card_token}</Text>
+      <Text>Expiry: {item.expiry_date}</Text>
+    </View>
+  );
+
+  return (
+    <View style={styles.container}>
+      {loading ? <Text>Loading...</Text> : (
+        <FlatList
+          data={cards}
+          keyExtractor={(item) => item.card_id.toString()}
+          renderItem={renderItem}
+          ListEmptyComponent={<Text>No gift cards found.</Text>}
+        />
+      )}
+      <Button title="Consolidate Cards" onPress={handleConsolidate} />
+      {message ? <Text style={styles.message}>{message}</Text> : null}
+    </View>
+  );
+};
+
+export default GiftCardListScreen;
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 20 },
+  cardItem: { padding: 10, borderBottomWidth: 1, borderColor: '#ccc' },
+  message: { marginTop: 10, textAlign: 'center' },
+});

--- a/mobile/HomeScreen.js
+++ b/mobile/HomeScreen.js
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, Button } from 'react-native';
 import { sessionInfo } from './api';
 
-const HomeScreen = () => {
+const HomeScreen = ({ navigation }) => {
   const [userId, setUserId] = useState(null);
 
   useEffect(() => {
@@ -18,7 +18,21 @@ const HomeScreen = () => {
   return (
     <View style={styles.container}>
       {userId ? (
-        <Text style={styles.text}>Welcome, user {userId}!</Text>
+        <>
+          <Text style={styles.text}>Welcome, user {userId}!</Text>
+          <Button
+            title="View Gift Cards"
+            onPress={() => navigation.navigate('GiftCards')}
+          />
+          <Button
+            title="Link Bank Account"
+            onPress={() => navigation.navigate('BankLink')}
+          />
+          <Button
+            title="Make Purchase"
+            onPress={() => navigation.navigate('Purchase')}
+          />
+        </>
       ) : (
         <Text style={styles.text}>Loading...</Text>
       )}

--- a/mobile/PurchaseScreen.js
+++ b/mobile/PurchaseScreen.js
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { makePurchase, sessionInfo } from './api';
+
+const PurchaseScreen = () => {
+  const [userId, setUserId] = useState(null);
+  const [amount, setAmount] = useState('');
+  const [paymentToken, setPaymentToken] = useState('');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const loadSession = async () => {
+      const info = await sessionInfo();
+      if (info?.authenticated) {
+        setUserId(info.user_id);
+      }
+    };
+    loadSession();
+  }, []);
+
+  const handlePurchase = async () => {
+    if (!userId || !amount || !paymentToken) return;
+    const res = await makePurchase(userId, Number(amount), paymentToken);
+    if (res?.message) {
+      setMessage(res.message);
+    } else if (res?.error) {
+      setMessage(res.error);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Make Purchase</Text>
+      <TextInput
+        placeholder="Amount"
+        value={amount}
+        onChangeText={setAmount}
+        keyboardType="numeric"
+        style={styles.input}
+      />
+      <TextInput
+        placeholder="Payment token"
+        value={paymentToken}
+        onChangeText={setPaymentToken}
+        style={styles.input}
+      />
+      <Button title="Purchase" onPress={handlePurchase} />
+      {message ? <Text style={styles.message}>{message}</Text> : null}
+    </View>
+  );
+};
+
+export default PurchaseScreen;
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 20, backgroundColor: '#fff' },
+  title: { fontSize: 20, marginBottom: 10, textAlign: 'center' },
+  input: { borderWidth: 1, borderColor: '#ccc', padding: 8, marginVertical: 10, borderRadius: 6 },
+  message: { marginTop: 20, textAlign: 'center' },
+});

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -21,6 +21,12 @@ The app now starts on a **Login** screen. Provide your registered email and
 password and press **Login**.  On success you will be taken to the home screen
 which fetches session information from the backend.
 
+From the home screen you can navigate to additional flows:
+
+- **Gift Cards** – lists the user's gift cards and offers a button to consolidate them.
+- **Link Bank Account** – allows submitting a bank token to link via the backend.
+- **Make Purchase** – submit an amount and payment token to create a purchase.
+
 Ensure the backend server is running and accessible before attempting to log in.
 
 ### Configuring the backend URL


### PR DESCRIPTION
## Summary
- add GiftCardListScreen with consolidation option
- add BankLinkScreen and PurchaseScreen
- wire screens into the app navigation
- extend HomeScreen with buttons to reach new flows
- document new navigation in mobile README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688732e113688325a211c2819cba9873