### PR TITLE
Implement /api/consolidate endpoint

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -6,6 +6,7 @@ from flask_limiter.errors import RateLimitExceeded
 from flask_login import login_user, logout_user, current_user, login_required
 from .__init__ import bcrypt, csrf
 from .aml import log_transaction
+from .stripeUtils import issue_virtual_card
 from datetime import datetime
 from .config import Config
 
@@ -192,6 +193,53 @@ def add_gift_card():
     db.session.add(new_card)
     db.session.commit()
     return jsonify({"message": "card added", "card_id": new_card.card_id}), 201
+
+
+@api_bp.route("/consolidate", methods=["POST"])
+@login_required
+def consolidate_cards():
+    """Consolidate a user's gift cards onto a platform card."""
+    data = request.get_json() or {}
+    user_id = data.get("user_id")
+    try:
+        user_id = int(user_id)
+    except (TypeError, ValueError):
+        return jsonify({"error": "Invalid user_id"}), 400
+    if user_id != current_user.user_id:
+        return jsonify({"error": "forbidden"}), 403
+
+    user = db.session.get(User, user_id)
+    if not user:
+        return jsonify({"error": "User not found"}), 404
+
+    cards = GiftCard.query.filter_by(user_id=user_id, is_active=True).all()
+    if not cards:
+        return jsonify({"error": "No active cards"}), 400
+
+    platform_card = PlatformGiftCard.query.filter_by(user_id=user_id).first()
+    if not platform_card:
+        try:
+            virt = issue_virtual_card(user.name, user.email)
+            platform_card = PlatformGiftCard(
+                user_id=user_id, stripe_card_id=getattr(virt, "id", None)
+            )
+            db.session.add(platform_card)
+        except Exception as e:  # pragma: no cover - stripe failure
+            return jsonify({"error": str(e)}), 400
+
+    for card in cards:
+        card.is_active = False
+
+    db.session.commit()
+    log_transaction(user_id=user_id, amount=0.0, transaction_type="consolidate")
+
+    return jsonify(
+        {
+            "message": "consolidation complete",
+            "platform_card_id": platform_card.card_id,
+            "deactivated": len(cards),
+        }
+    )
 
 
 

--- a/backend/tests/test_consolidate.py
+++ b/backend/tests/test_consolidate.py
@@ -1,0 +1,50 @@
+import os
+from datetime import datetime
+
+os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test")
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("SECRET_KEY", "test")
+
+from app.__init__ import create_app, db, bcrypt
+from app.models import User, GiftCard, PlatformGiftCard
+
+
+def setup_app():
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def create_user(app):
+    with app.app_context():
+        pw = bcrypt.generate_password_hash("pw").decode("utf-8")
+        user = User(name="U", email="u@example.com", password_hash=pw)
+        db.session.add(user)
+        db.session.commit()
+        return user.user_id
+
+
+def test_consolidate_cards(mocker):
+    app = setup_app()
+    user_id = create_user(app)
+    with app.app_context():
+        card1 = GiftCard(user_id=user_id, token="tok1", expiry_date=datetime(2099,1,1), source="physical")
+        card2 = GiftCard(user_id=user_id, token="tok2", expiry_date=datetime(2099,1,1), source="physical")
+        db.session.add_all([card1, card2])
+        db.session.commit()
+
+    client = app.test_client()
+    client.post('/api/login', json={'email': 'u@example.com', 'password': 'pw'})
+
+    mocker.patch('app.routes.issue_virtual_card', return_value=type('obj',(object,),{'id':'pc_123'})())
+
+    resp = client.post('/api/consolidate', json={'user_id': user_id})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['message'] == 'consolidation complete'
+
+    with app.app_context():
+        cards = GiftCard.query.filter_by(user_id=user_id).all()
+        assert all(not c.is_active for c in cards)
+        assert PlatformGiftCard.query.filter_by(user_id=user_id).count() == 1


### PR DESCRIPTION
## Summary
- add missing API route to consolidate gift cards
- create new tests for consolidation

## Testing
- `pytest -q`
- `npm test` in `frontend`
- `npm test` in `mobile`

------
https://chatgpt.com/codex/tasks/task_e_6887341bea048325a736a053fe9d8046