### PR TITLE
Add testing and release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,25 @@ python run.py
 gunicorn wsgi:app
 ```
 
+## Running tests
+
+Each part of the project includes automated tests. To run them locally you will
+need Python and Node.js installed.
+
+```bash
+# Backend tests
+cd backend
+pytest
+
+# Frontend tests
+cd ../frontend
+npm test
+
+# Mobile tests
+cd ../mobile
+npm test
+```
+
 ### Docker
 
 You can build the API server into a container using the provided Dockerfile:

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -40,3 +40,24 @@ BACKEND_URL="http://192.168.1.42:8000" npx expo start
 ```
 
 This value is read in `api.js` and used as the base URL for all network calls.
+
+### Running tests
+
+Run the Jest test suite with:
+
+```bash
+npm test
+```
+
+### Building a release
+
+Install the EAS CLI and build for Android or iOS:
+
+```bash
+npm install -g eas-cli
+eas login
+eas build --platform android  # or ios
+```
+
+Provide environment variables such as `BACKEND_URL` or `STRIPE_PUBLISHABLE_KEY`
+via an `eas.json` profile or `--env` flags when building.


### PR DESCRIPTION
## Summary
- document how to run tests for backend, frontend and mobile
- show steps to run the mobile tests and build a release APK/IPA

## Testing
- `pytest -q`
- `npm test --if-present` in `frontend`
- `npm test --if-present` in `mobile`

------
https://chatgpt.com/codex/tasks/task_e_688737f9ce708325a74510f8ebc355a3