### PR TITLE
Improve mobile UI styling and navigation

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { COLORS } from './theme';
 import LoginScreen from './LoginScreen';
 import HomeScreen from './HomeScreen';
 import GiftCardListScreen from './GiftCardListScreen';
@@ -12,12 +13,23 @@ const Stack = createNativeStackNavigator();
 export default function App() {
   return (
     <NavigationContainer>
-      <Stack.Navigator initialRouteName="Login">
-        <Stack.Screen name="Login" component={LoginScreen} options={{ headerShown: false }} />
-        <Stack.Screen name="Home" component={HomeScreen} />
-        <Stack.Screen name="GiftCards" component={GiftCardListScreen} />
-        <Stack.Screen name="BankLink" component={BankLinkScreen} />
-        <Stack.Screen name="Purchase" component={PurchaseScreen} />
+      <Stack.Navigator
+        initialRouteName="Login"
+        screenOptions={{
+          headerStyle: { backgroundColor: COLORS.primary },
+          headerTintColor: '#fff',
+          headerTitleAlign: 'center',
+        }}
+      >
+        <Stack.Screen
+          name="Login"
+          component={LoginScreen}
+          options={{ headerShown: false }}
+        />
+        <Stack.Screen name="Home" component={HomeScreen} options={{ title: 'Home' }} />
+        <Stack.Screen name="GiftCards" component={GiftCardListScreen} options={{ title: 'Gift Cards' }} />
+        <Stack.Screen name="BankLink" component={BankLinkScreen} options={{ title: 'Link Bank Account' }} />
+        <Stack.Screen name="Purchase" component={PurchaseScreen} options={{ title: 'Purchase' }} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/mobile/BankLinkScreen.js
+++ b/mobile/BankLinkScreen.js
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { View, Text, TextInput, Button, StyleSheet, ActivityIndicator } from 'react-native';
 import { linkBankAccount, sessionInfo } from './api';
+import { COLORS, SPACING, FONT_SIZES } from './theme';
 
 const BankLinkScreen = () => {
   const [userId, setUserId] = useState(null);
   const [bankToken, setBankToken] = useState('');
   const [message, setMessage] = useState('');
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     const loadSession = async () => {
@@ -23,12 +25,14 @@ const BankLinkScreen = () => {
       setMessage('Enter bank token');
       return;
     }
+    setLoading(true);
     const res = await linkBankAccount(userId, bankToken);
     if (res?.message) {
       setMessage(res.message);
     } else if (res?.error) {
       setMessage(res.error);
     }
+    setLoading(false);
   };
 
   return (
@@ -40,7 +44,11 @@ const BankLinkScreen = () => {
         onChangeText={setBankToken}
         style={styles.input}
       />
-      <Button title="Link" onPress={handleLink} />
+      {loading ? (
+        <ActivityIndicator size="large" color={COLORS.primary} />
+      ) : (
+        <Button title="Link" onPress={handleLink} />
+      )}
       {message ? <Text style={styles.message}>{message}</Text> : null}
     </View>
   );
@@ -49,8 +57,27 @@ const BankLinkScreen = () => {
 export default BankLinkScreen;
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: 20, backgroundColor: '#fff' },
-  title: { fontSize: 20, marginBottom: 10, textAlign: 'center' },
-  input: { borderWidth: 1, borderColor: '#ccc', padding: 8, marginVertical: 10, borderRadius: 6 },
-  message: { marginTop: 20, textAlign: 'center' },
+  container: {
+    flex: 1,
+    padding: SPACING,
+    backgroundColor: COLORS.background,
+  },
+  title: {
+    fontSize: FONT_SIZES.title,
+    marginBottom: SPACING / 2,
+    textAlign: 'center',
+    color: COLORS.text,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    padding: SPACING / 2,
+    marginVertical: SPACING / 2,
+    borderRadius: 6,
+  },
+  message: {
+    marginTop: SPACING,
+    textAlign: 'center',
+    color: COLORS.text,
+  },
 });

--- a/mobile/GiftCardListScreen.js
+++ b/mobile/GiftCardListScreen.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, FlatList, Button, StyleSheet } from 'react-native';
+import { View, Text, FlatList, Button, StyleSheet, ActivityIndicator } from 'react-native';
 import { fetchGiftCards, consolidateGiftCards, sessionInfo } from './api';
+import { COLORS, SPACING, FONT_SIZES } from './theme';
 
 const GiftCardListScreen = () => {
   const [userId, setUserId] = useState(null);
@@ -41,20 +42,22 @@ const GiftCardListScreen = () => {
 
   const renderItem = ({ item }) => (
     <View style={styles.cardItem}>
-      <Text>Card ID: {item.card_id}</Text>
-      <Text>Token: {item.card_token}</Text>
-      <Text>Expiry: {item.expiry_date}</Text>
+      <Text style={styles.cardText}>Card ID: {item.card_id}</Text>
+      <Text style={styles.cardText}>Token: {item.card_token}</Text>
+      <Text style={styles.cardText}>Expiry: {item.expiry_date}</Text>
     </View>
   );
 
   return (
     <View style={styles.container}>
-      {loading ? <Text>Loading...</Text> : (
+      {loading ? (
+        <ActivityIndicator size="large" color={COLORS.primary} />
+      ) : (
         <FlatList
           data={cards}
           keyExtractor={(item) => item.card_id.toString()}
           renderItem={renderItem}
-          ListEmptyComponent={<Text>No gift cards found.</Text>}
+          ListEmptyComponent={<Text style={styles.cardText}>No gift cards found.</Text>}
         />
       )}
       <Button title="Consolidate Cards" onPress={handleConsolidate} />
@@ -66,7 +69,23 @@ const GiftCardListScreen = () => {
 export default GiftCardListScreen;
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: 20 },
-  cardItem: { padding: 10, borderBottomWidth: 1, borderColor: '#ccc' },
-  message: { marginTop: 10, textAlign: 'center' },
+  container: {
+    flex: 1,
+    padding: SPACING,
+    backgroundColor: COLORS.background,
+  },
+  cardItem: {
+    padding: SPACING / 2,
+    borderBottomWidth: 1,
+    borderColor: COLORS.border,
+  },
+  cardText: {
+    fontSize: FONT_SIZES.text,
+    color: COLORS.text,
+  },
+  message: {
+    marginTop: SPACING,
+    textAlign: 'center',
+    color: COLORS.text,
+  },
 });

--- a/mobile/HomeScreen.js
+++ b/mobile/HomeScreen.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet, Button } from 'react-native';
+import { View, Text, StyleSheet, Button, ActivityIndicator } from 'react-native';
 import { sessionInfo, logoutUser } from './api';
+import { COLORS, FONT_SIZES, SPACING } from './theme';
 
 const HomeScreen = ({ navigation }) => {
   const [userId, setUserId] = useState(null);
@@ -41,7 +42,7 @@ const HomeScreen = ({ navigation }) => {
           />
         </>
       ) : (
-        <Text style={styles.text}>Loading...</Text>
+        <ActivityIndicator size="large" color={COLORS.primary} />
       )}
     </View>
   );
@@ -54,9 +55,12 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: '#fff',
+    backgroundColor: COLORS.background,
+    padding: SPACING,
   },
   text: {
-    fontSize: 18,
+    fontSize: FONT_SIZES.text,
+    color: COLORS.text,
+    marginBottom: SPACING,
   },
 });

--- a/mobile/LoginScreen.js
+++ b/mobile/LoginScreen.js
@@ -1,13 +1,16 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { View, Text, TextInput, Button, StyleSheet, ActivityIndicator } from 'react-native';
+import { COLORS, SPACING, FONT_SIZES } from './theme';
 import { loginUser, sessionInfo } from './api';
 
 const LoginScreen = ({ navigation }) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [message, setMessage] = useState('');
+  const [loading, setLoading] = useState(false);
 
   const handleLogin = async () => {
+    setLoading(true);
     const res = await loginUser(email, password);
     if (res?.error) {
       setMessage(res.error);
@@ -19,6 +22,7 @@ const LoginScreen = ({ navigation }) => {
         setMessage('Login failed');
       }
     }
+    setLoading(false);
   };
 
   return (
@@ -37,7 +41,11 @@ const LoginScreen = ({ navigation }) => {
         secureTextEntry
         style={styles.input}
       />
-      <Button title="Login" onPress={handleLogin} />
+      {loading ? (
+        <ActivityIndicator size="large" color={COLORS.primary} />
+      ) : (
+        <Button title="Login" onPress={handleLogin} />
+      )}
       {message ? <Text style={styles.message}>{message}</Text> : null}
     </View>
   );
@@ -48,25 +56,27 @@ export default LoginScreen;
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    padding: 20,
+    padding: SPACING,
     justifyContent: 'center',
-    backgroundColor: '#fff',
+    backgroundColor: COLORS.background,
   },
   title: {
-    fontSize: 24,
+    fontSize: FONT_SIZES.title,
     fontWeight: 'bold',
-    marginBottom: 20,
+    marginBottom: SPACING,
     textAlign: 'center',
+    color: COLORS.text,
   },
   input: {
     borderWidth: 1,
-    borderColor: '#ccc',
-    padding: 8,
-    marginVertical: 10,
+    borderColor: COLORS.border,
+    padding: SPACING / 2,
+    marginVertical: SPACING / 2,
     borderRadius: 6,
   },
   message: {
-    marginTop: 20,
+    marginTop: SPACING,
     textAlign: 'center',
+    color: COLORS.text,
   },
 });

--- a/mobile/PurchaseScreen.js
+++ b/mobile/PurchaseScreen.js
@@ -1,12 +1,14 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { View, Text, TextInput, Button, StyleSheet, ActivityIndicator } from 'react-native';
 import { makePurchase, sessionInfo } from './api';
+import { COLORS, SPACING, FONT_SIZES } from './theme';
 
 const PurchaseScreen = () => {
   const [userId, setUserId] = useState(null);
   const [amount, setAmount] = useState('');
   const [paymentToken, setPaymentToken] = useState('');
   const [message, setMessage] = useState('');
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     const loadSession = async () => {
@@ -25,12 +27,14 @@ const PurchaseScreen = () => {
       setMessage('Enter a valid amount');
       return;
     }
+    setLoading(true);
     const res = await makePurchase(userId, amt, paymentToken);
     if (res?.message) {
       setMessage(res.message);
     } else if (res?.error) {
       setMessage(res.error);
     }
+    setLoading(false);
   };
 
   return (
@@ -49,7 +53,11 @@ const PurchaseScreen = () => {
         onChangeText={setPaymentToken}
         style={styles.input}
       />
-      <Button title="Purchase" onPress={handlePurchase} />
+      {loading ? (
+        <ActivityIndicator size="large" color={COLORS.primary} />
+      ) : (
+        <Button title="Purchase" onPress={handlePurchase} />
+      )}
       {message ? <Text style={styles.message}>{message}</Text> : null}
     </View>
   );
@@ -58,8 +66,27 @@ const PurchaseScreen = () => {
 export default PurchaseScreen;
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: 20, backgroundColor: '#fff' },
-  title: { fontSize: 20, marginBottom: 10, textAlign: 'center' },
-  input: { borderWidth: 1, borderColor: '#ccc', padding: 8, marginVertical: 10, borderRadius: 6 },
-  message: { marginTop: 20, textAlign: 'center' },
+  container: {
+    flex: 1,
+    padding: SPACING,
+    backgroundColor: COLORS.background,
+  },
+  title: {
+    fontSize: FONT_SIZES.title,
+    marginBottom: SPACING / 2,
+    textAlign: 'center',
+    color: COLORS.text,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    padding: SPACING / 2,
+    marginVertical: SPACING / 2,
+    borderRadius: 6,
+  },
+  message: {
+    marginTop: SPACING,
+    textAlign: 'center',
+    color: COLORS.text,
+  },
 });

--- a/mobile/theme.js
+++ b/mobile/theme.js
@@ -1,0 +1,13 @@
+export const COLORS = {
+  background: '#ffffff',
+  primary: '#3478f6',
+  text: '#333333',
+  border: '#cccccc',
+};
+
+export const SPACING = 16;
+
+export const FONT_SIZES = {
+  title: 24,
+  text: 18,
+};


### PR DESCRIPTION
## Summary
- add navigation header styling and titles
- apply consistent styling via new theme constants
- show activity indicators while loading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887478d289c8325bf2848b691e9c0e8