### PR TITLE
Fix bank name retrieval in link account

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -281,7 +281,7 @@ def link_bank_account():
     new_account = BankAccount(
         user_id=user_id,
         stripe_bank_account_id=bank_account.id,
-        bank_name=getattr(bank_account, "bank_name", None) or getattr(bank_account, "bank_name", None),
+        bank_name=getattr(bank_account, "bank_name", None),
         last4=getattr(bank_account, "last4", None),
     )
     db.session.add(new_account)


### PR DESCRIPTION
## Summary
- simplify `bank_name` lookup when linking bank accounts

## Testing
- `pytest -q backend/tests/test_bank_accounts.py::test_link_bank_account`

------
https://chatgpt.com/codex/tasks/task_e_68874c825ddc832581774caf9f28f245