### PR TITLE
Fix region field typo in Stripe utils

### DIFF
--- a/backend/app/stripeUtils.py
+++ b/backend/app/stripeUtils.py
@@ -28,7 +28,7 @@ def issue_virtual_card(user_name, user_email):
             "address": {
                 "line1": "Placeholder Address",
                 "city": "Placeholder City",
-                "region": "Placeholder Reigon",
+                "region": "Placeholder Region",
                 "country": "NZ",
                 "postal_code": "00000"
             }


### PR DESCRIPTION
## Summary
- fix misspelled region in `stripeUtils.py`

## Testing
- `pytest backend/tests/test_consolidate.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68874d5719a48325b58a296b67b7072e