### PR TITLE
Persist KYC profile totals

### DIFF
--- a/backend/app/kyc.py
+++ b/backend/app/kyc.py
@@ -22,16 +22,15 @@ class UserProfile:
         self.user_id = user_id
         self.db_profile = db_profile
         self.kyc_status = db_profile.verification_status
-        self.daily_total = 0.0
-        self.weekly_total = 0.0
+        self.daily_total = db_profile.daily_total or 0.0
+        self.weekly_total = db_profile.weekly_total or 0.0
         self.card_balances: list[tuple[int, float]] = []
         self.txn_log: list[tuple[float, str, list, datetime]] = []
         self.flagged = db_profile.flagged
-        self._day = datetime.utcnow().date()
-        self._week_start = self._day - timedelta(days=self._day.weekday())
-
-
-_profiles: dict[int, UserProfile] = {}
+        self._day = db_profile.day or datetime.utcnow().date()
+        self._week_start = db_profile.week_start or (
+            self._day - timedelta(days=self._day.weekday())
+        )
 
 
 def get_user_profile(user_id: int) -> UserProfile:
@@ -40,14 +39,7 @@ def get_user_profile(user_id: int) -> UserProfile:
         db_profile = ProfileModel(user_id=user_id)
         db.session.add(db_profile)
         db.session.commit()
-    profile = _profiles.get(user_id)
-    if not profile:
-        profile = UserProfile(user_id, db_profile)
-        _profiles[user_id] = profile
-    else:
-        profile.db_profile = db_profile
-        profile.kyc_status = db_profile.verification_status
-        profile.flagged = db_profile.flagged
+    profile = UserProfile(user_id, db_profile)
     return profile
 
 
@@ -60,6 +52,10 @@ def _reset_totals_if_needed(user: UserProfile) -> None:
     if user._week_start != week_start:
         user._week_start = week_start
         user.weekly_total = 0.0
+    user.db_profile.day = user._day
+    user.db_profile.week_start = user._week_start
+    user.db_profile.daily_total = user.daily_total
+    user.db_profile.weekly_total = user.weekly_total
 
 
 def process_transaction(user: UserProfile, amount: float, merchant_id: str, source_cards: list):
@@ -70,6 +66,10 @@ def process_transaction(user: UserProfile, amount: float, merchant_id: str, sour
 
     user.daily_total += amount
     user.weekly_total += amount
+    user.db_profile.daily_total = user.daily_total
+    user.db_profile.weekly_total = user.weekly_total
+    user.db_profile.day = user._day
+    user.db_profile.week_start = user._week_start
     user.txn_log.append((amount, merchant_id, source_cards, datetime.utcnow()))
 
     total_consolidated = sum(balance for _, balance in user.card_balances)
@@ -81,6 +81,9 @@ def process_transaction(user: UserProfile, amount: float, merchant_id: str, sour
 
     if detect_structuring(user):
         flag_suspicious(user, reason="Suspected structuring to avoid AML triggers")
+
+    db.session.add(user.db_profile)
+    db.session.commit()
 
 
 def trigger_kyc(user: UserProfile, reason: str):

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, date, timedelta
 from flask_login import UserMixin
 from .__init__ import db
 
@@ -71,6 +71,10 @@ class UserProfile(db.Model):
     verification_status = db.Column(db.String, nullable=False, default='not_verified')
     veriff_session_id = db.Column(db.String, nullable=True)
     flagged = db.Column(db.Boolean, default=False)
+    daily_total = db.Column(db.Float, default=0.0)
+    weekly_total = db.Column(db.Float, default=0.0)
+    day = db.Column(db.Date, default=date.today)
+    week_start = db.Column(db.Date, default=lambda: date.today() - timedelta(days=date.today().weekday()))
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 

--- a/backend/migrations/versions/0007_profile_totals.py
+++ b/backend/migrations/versions/0007_profile_totals.py
@@ -1,0 +1,22 @@
+"""add transaction total fields to user profile"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0007'
+down_revision = '0006'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('user_profiles', sa.Column('daily_total', sa.Float(), nullable=False, server_default='0'))
+    op.add_column('user_profiles', sa.Column('weekly_total', sa.Float(), nullable=False, server_default='0'))
+    op.add_column('user_profiles', sa.Column('day', sa.Date(), nullable=True))
+    op.add_column('user_profiles', sa.Column('week_start', sa.Date(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('user_profiles', 'week_start')
+    op.drop_column('user_profiles', 'day')
+    op.drop_column('user_profiles', 'weekly_total')
+    op.drop_column('user_profiles', 'daily_total')

--- a/backend/tests/test_kyc.py
+++ b/backend/tests/test_kyc.py
@@ -46,3 +46,20 @@ def test_single_large_transaction_flagged(mocker):
         profile = kyc.get_user_profile(user_id)
         assert profile.flagged is True
         assert UserProfile.query.get(user_id).flagged is True
+
+
+def test_transaction_totals_persist():
+    app = setup_app()
+    user_id = create_user(app)
+    with app.app_context():
+        aml.log_transaction(user_id, 100, "purchase")
+        aml.log_transaction(user_id, 50, "purchase")
+        profile = kyc.get_user_profile(user_id)
+        assert profile.daily_total == 150
+        assert profile.weekly_total == 150
+        # ensure fetching again reflects stored totals
+        profile2 = kyc.get_user_profile(user_id)
+        assert profile2.daily_total == 150
+        db_profile = UserProfile.query.get(user_id)
+        assert db_profile.daily_total == 150
+        assert db_profile.weekly_total == 150


### PR DESCRIPTION
## Summary
- persist transaction totals inside `UserProfile`
- update KYC processing logic to write/read totals from DB
- add Alembic migration for new columns
- test persistence of transaction totals

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887c75cfbbc83259e59beec9d3480c9