### PR TITLE
Enforce missing secrets cause startup error

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -46,6 +46,18 @@ def create_app():
     app = Flask(__name__)
     app.config.from_object(Config)
 
+    required_keys = {
+        'SECRET_KEY': 'your_secret_key_here',
+        'STRIPE_SECRET_KEY': 'your_stripe_secret_key_here',
+        'STRIPE_PUBLISHABLE_KEY': 'your_stripe_publishable_key_here',
+        'STRIPE_WEBHOOK_SECRET': 'your_stripe_webhook_secret_here',
+    }
+
+    for key, placeholder in required_keys.items():
+        value = os.environ.get(key, app.config.get(key))
+        if not value or value == placeholder:
+            raise RuntimeError(f"{key} environment variable is required")
+
     # Configure logging to stdout or a file
     log_file = os.getenv("LOG_FILE")
     log_level = os.getenv("LOG_LEVEL", "INFO").upper()

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -2,9 +2,14 @@
 import os
 
 class Config:
-    SECRET_KEY = os.environ.get("SECRET_KEY") or "your_secret_key_here"
+    """Application configuration loaded from environment variables."""
 
     env = os.getenv("FLASK_ENV", "production")
+
+    SECRET_KEY = os.environ.get("SECRET_KEY") or "your_secret_key_here"
+    if env != "development" and SECRET_KEY == "your_secret_key_here":
+        raise RuntimeError("SECRET_KEY environment variable must be set for production")
+
     if env == "development":
         SQLALCHEMY_DATABASE_URI = os.environ.get("DATABASE_URL", "sqlite:///site.db")
     else:
@@ -26,6 +31,13 @@ class Config:
         'your_stripe_publishable_key_here'
     )
     STRIPE_WEBHOOK_SECRET = os.environ.get('STRIPE_WEBHOOK_SECRET', 'your_stripe_webhook_secret_here')
+
+    if env != "development" and (
+        STRIPE_SECRET_KEY == 'your_stripe_secret_key_here'
+        or STRIPE_PUBLISHABLE_KEY == 'your_stripe_publishable_key_here'
+        or STRIPE_WEBHOOK_SECRET == 'your_stripe_webhook_secret_here'
+    ):
+        raise RuntimeError('Stripe keys must be configured for production')
 
     # Comma-separated list of origins allowed to access the API
     CORS_ORIGINS = os.environ.get('CORS_ORIGINS', '*')

--- a/backend/tests/test_account_deletion.py
+++ b/backend/tests/test_account_deletion.py
@@ -1,6 +1,8 @@
 import os
 
 os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test")
+os.environ.setdefault("STRIPE_PUBLISHABLE_KEY", "pk_test")
+os.environ.setdefault("STRIPE_WEBHOOK_SECRET", "whsec_test")
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 os.environ.setdefault("SECRET_KEY", "test")
 

--- a/backend/tests/test_aml.py
+++ b/backend/tests/test_aml.py
@@ -1,6 +1,8 @@
 import os
 
 os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test")
+os.environ.setdefault("STRIPE_PUBLISHABLE_KEY", "pk_test")
+os.environ.setdefault("STRIPE_WEBHOOK_SECRET", "whsec_test")
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 os.environ.setdefault("SECRET_KEY", "test")
 os.environ.setdefault("AML_THRESHOLD", "5000")

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -2,6 +2,8 @@ import os
 import pytest
 
 os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test")
+os.environ.setdefault("STRIPE_PUBLISHABLE_KEY", "pk_test")
+os.environ.setdefault("STRIPE_WEBHOOK_SECRET", "whsec_test")
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 os.environ.setdefault("SECRET_KEY", "test")
 

--- a/backend/tests/test_bank_accounts.py
+++ b/backend/tests/test_bank_accounts.py
@@ -2,6 +2,8 @@ import os
 import pytest
 
 os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test")
+os.environ.setdefault("STRIPE_PUBLISHABLE_KEY", "pk_test")
+os.environ.setdefault("STRIPE_WEBHOOK_SECRET", "whsec_test")
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 os.environ.setdefault("SECRET_KEY", "test")
 

--- a/backend/tests/test_cards.py
+++ b/backend/tests/test_cards.py
@@ -2,6 +2,8 @@ import os
 import pytest
 
 os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test")
+os.environ.setdefault("STRIPE_PUBLISHABLE_KEY", "pk_test")
+os.environ.setdefault("STRIPE_WEBHOOK_SECRET", "whsec_test")
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 os.environ.setdefault("SECRET_KEY", "test")
 

--- a/backend/tests/test_consolidate.py
+++ b/backend/tests/test_consolidate.py
@@ -2,6 +2,8 @@ import os
 from datetime import datetime
 
 os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test")
+os.environ.setdefault("STRIPE_PUBLISHABLE_KEY", "pk_test")
+os.environ.setdefault("STRIPE_WEBHOOK_SECRET", "whsec_test")
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 os.environ.setdefault("SECRET_KEY", "test")
 

--- a/backend/tests/test_kyc.py
+++ b/backend/tests/test_kyc.py
@@ -1,5 +1,7 @@
 import os
 os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test")
+os.environ.setdefault("STRIPE_PUBLISHABLE_KEY", "pk_test")
+os.environ.setdefault("STRIPE_WEBHOOK_SECRET", "whsec_test")
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 os.environ.setdefault("SECRET_KEY", "test")
 

--- a/backend/tests/test_missing_secrets.py
+++ b/backend/tests/test_missing_secrets.py
@@ -1,0 +1,31 @@
+import os
+import importlib
+import pytest
+
+
+def reload_modules():
+    import app.config
+    import app.__init__
+    importlib.reload(app.config)
+    importlib.reload(app.__init__)
+    return app.__init__
+
+
+@pytest.mark.parametrize("missing_key", [
+    "SECRET_KEY",
+    "STRIPE_SECRET_KEY",
+    "STRIPE_PUBLISHABLE_KEY",
+    "STRIPE_WEBHOOK_SECRET",
+])
+def test_create_app_fails_without_required_env(monkeypatch, missing_key):
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+    # provide valid values for all keys then remove one
+    monkeypatch.setenv("SECRET_KEY", "v")
+    monkeypatch.setenv("STRIPE_SECRET_KEY", "sk")
+    monkeypatch.setenv("STRIPE_PUBLISHABLE_KEY", "pk")
+    monkeypatch.setenv("STRIPE_WEBHOOK_SECRET", "wh")
+    monkeypatch.delenv(missing_key, raising=False)
+
+    with pytest.raises(RuntimeError):
+        modules = reload_modules()
+        modules.create_app()

--- a/backend/tests/test_purchase.py
+++ b/backend/tests/test_purchase.py
@@ -1,6 +1,8 @@
 import os
 
 os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test")
+os.environ.setdefault("STRIPE_PUBLISHABLE_KEY", "pk_test")
+os.environ.setdefault("STRIPE_WEBHOOK_SECRET", "whsec_test")
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 os.environ.setdefault("SECRET_KEY", "test")
 

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -2,6 +2,8 @@ import os
 import pytest
 
 os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test")
+os.environ.setdefault("STRIPE_PUBLISHABLE_KEY", "pk_test")
+os.environ.setdefault("STRIPE_WEBHOOK_SECRET", "whsec_test")
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 os.environ.setdefault("SECRET_KEY", "test")
 os.environ.setdefault("RATE_LIMIT", "1/minute")

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -3,6 +3,8 @@ import builtins
 import pytest
 
 os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test")
+os.environ.setdefault("STRIPE_PUBLISHABLE_KEY", "pk_test")
+os.environ.setdefault("STRIPE_WEBHOOK_SECRET", "whsec_test")
 
 from app.encryption_utils import encrypt_data, decrypt_data
 from app.routes import create_payment_intent, verify_payment


### PR DESCRIPTION
## Summary
- fail fast in production when required secret values are missing
- check for missing/placeholder secrets during app creation
- update tests to include Stripe publishable & webhook keys
- add tests expecting failure when secrets are absent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887cdcbddbc83258ef54bad6252e8c7