### PR TITLE
Persist card balances

### DIFF
--- a/backend/app/kyc.py
+++ b/backend/app/kyc.py
@@ -7,6 +7,7 @@ from .models import (
     VerificationAuditLog,
     KYCRecord,
     AMLLogEntry,
+    CardBalance,
 )
 from .veriff_service import create_verification_session
 
@@ -24,7 +25,10 @@ class UserProfile:
         self.kyc_status = db_profile.verification_status
         self.daily_total = db_profile.daily_total or 0.0
         self.weekly_total = db_profile.weekly_total or 0.0
-        self.card_balances: list[tuple[int, float]] = []
+        balances = CardBalance.query.filter_by(user_id=user_id).all()
+        self.card_balances: list[tuple[int, float]] = [
+            (b.card_id, b.balance) for b in balances
+        ]
         self.txn_log: list[tuple[float, str, list, datetime]] = []
         self.flagged = db_profile.flagged
         self._day = db_profile.day or datetime.utcnow().date()
@@ -58,8 +62,29 @@ def _reset_totals_if_needed(user: UserProfile) -> None:
     user.db_profile.weekly_total = user.weekly_total
 
 
+def update_card_balance(user: UserProfile, card_id: int, balance: float) -> None:
+    """Persist a card balance for monitoring purposes."""
+    for idx, (cid, _) in enumerate(user.card_balances):
+        if cid == card_id:
+            user.card_balances[idx] = (card_id, balance)
+            break
+    else:
+        user.card_balances.append((card_id, balance))
+
+    cb = CardBalance.query.filter_by(user_id=user.user_id, card_id=card_id).first()
+    if not cb:
+        cb = CardBalance(user_id=user.user_id, card_id=card_id, balance=balance)
+        db.session.add(cb)
+    else:
+        cb.balance = balance
+    db.session.commit()
+
+
 def process_transaction(user: UserProfile, amount: float, merchant_id: str, source_cards: list):
     _reset_totals_if_needed(user)
+
+    for cid, bal in source_cards:
+        update_card_balance(user, cid, bal)
 
     if amount > MAX_SINGLE_TXN_LIMIT:
         flag_suspicious(user, reason="Single transaction exceeds soft threshold")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -146,3 +146,12 @@ class AMLLogEntry(db.Model):
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
 
     user = db.relationship('User', backref='aml_logs')
+
+class CardBalance(db.Model):
+    __tablename__ = "card_balances"
+    user_id = db.Column(db.Integer, db.ForeignKey("users.user_id"), primary_key=True)
+    card_id = db.Column(db.Integer, primary_key=True)
+    balance = db.Column(db.Float, nullable=False, default=0.0)
+
+    user = db.relationship("User", backref="card_balances")
+

--- a/backend/migrations/versions/0008_card_balances.py
+++ b/backend/migrations/versions/0008_card_balances.py
@@ -1,0 +1,21 @@
+"""add card balance table"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0008'
+down_revision = '0007'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'card_balances',
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.user_id'), primary_key=True),
+        sa.Column('card_id', sa.Integer(), primary_key=True),
+        sa.Column('balance', sa.Float(), nullable=False, server_default='0'),
+    )
+
+
+def downgrade():
+    op.drop_table('card_balances')

--- a/backend/tests/test_kyc.py
+++ b/backend/tests/test_kyc.py
@@ -65,3 +65,14 @@ def test_transaction_totals_persist():
         db_profile = UserProfile.query.get(user_id)
         assert db_profile.daily_total == 150
         assert db_profile.weekly_total == 150
+
+
+def test_card_balances_persist():
+    app = setup_app()
+    user_id = create_user(app)
+    with app.app_context():
+        profile = kyc.get_user_profile(user_id)
+        kyc.update_card_balance(profile, 1, 20.0)
+        profile2 = kyc.get_user_profile(user_id)
+        assert profile2.card_balances == [(1, 20.0)]
+


### PR DESCRIPTION
## Summary
- add `CardBalance` model and migration
- load and persist card balances in KYC logic
- test persistence of balances

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887d6071de08325b40b8996f234d941