### PR TITLE
Secure key permissions

### DIFF
--- a/backend/app/encryption_utils.py
+++ b/backend/app/encryption_utils.py
@@ -13,7 +13,8 @@ def load_encryption_key():
             return key_file.read()
     else:
         key = Fernet.generate_key()
-        with open(ENCRYPTION_KEY_PATH, "wb") as key_file:
+        fd = os.open(ENCRYPTION_KEY_PATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "wb") as key_file:
             key_file.write(key)
         return key
 

--- a/backend/tests/test_encryption_utils.py
+++ b/backend/tests/test_encryption_utils.py
@@ -1,0 +1,16 @@
+import importlib
+import sys
+
+
+def test_generated_key_permissions(tmp_path, monkeypatch):
+    key_path = tmp_path / "enc.key"
+    monkeypatch.setenv("ENCRYPTION_KEY_PATH", str(key_path))
+    monkeypatch.delenv("ENCRYPTION_KEY", raising=False)
+
+    sys.modules.pop("app.encryption_utils", None)
+    eu = importlib.import_module("app.encryption_utils")
+    importlib.reload(eu)
+
+    assert key_path.exists()
+    mode = key_path.stat().st_mode & 0o777
+    assert mode == 0o600


### PR DESCRIPTION
## Summary
- ensure new encryption keys are stored with `0600` permissions
- add regression test for restrictive key permissions

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887f0f3ef1c8325886aea0808811138