### PR TITLE
Add frontend Docker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,17 +162,26 @@ cp backend/.env.example backend/.env
 docker run --env-file backend/.env -p 8000:8000 consolidator-backend
 ```
 
-A `docker-compose.yml` file is included to run the backend together with a
-persistent Redis instance used by Flask-Limiter:
+The frontend includes a Dockerfile as well. Build and run it to serve the Expo
+web preview:
+
+```bash
+docker build -t consolidator-frontend ./frontend
+cp frontend/.env.example frontend/.env
+docker run --env-file frontend/.env -p 19006:19006 consolidator-frontend
+```
+
+A `docker-compose.yml` file is included to run the API, Redis and the Expo
+frontend together:
 
 ```bash
 docker compose up --build
 ```
 
-The API will be available at `http://localhost:8000` and Redis data will be
-stored in the `redis-data` volume. When the services are running you can
-verify that `RATELIMIT_STORAGE_URL` and the variables from `.env` were passed
-to the container:
+The API will be available at `http://localhost:8000` and the Expo web interface
+at `http://localhost:19006`. Redis data will be stored in the `redis-data`
+volume. When the services are running you can verify that `RATELIMIT_STORAGE_URL`
+and the variables from `.env` were passed to the container:
 
 ```bash
 docker compose exec backend env | grep RATELIMIT_STORAGE_URL
@@ -181,7 +190,10 @@ docker compose exec backend env | grep RATELIMIT_STORAGE_URL
 Before starting the server, create a `.env` file for your local secrets:
 
 ```bash
+# copy example env files (run these from the repository root)
 cp backend/.env.example backend/.env
+# and for the frontend
+cp frontend/.env.example frontend/.env
 # then edit backend/.env and add your real credentials
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,16 @@ services:
       RATELIMIT_STORAGE_URL: redis://redis:6379/0
     depends_on:
       - redis
+  frontend:
+    build: ./frontend
+    env_file:
+      - ./frontend/.env
+    ports:
+      - "19006:19006"
+    environment:
+      BACKEND_URL: http://backend:8000
+    depends_on:
+      - backend
   redis:
     image: redis:7
     volumes:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,5 @@
+# Sample environment for the frontend Expo app
+# Replace these values with real credentials
+STRIPE_PUBLISHABLE_KEY=REPLACE_WITH_STRIPE_KEY
+BACKEND_URL=http://localhost:8000
+TOKENIZER_SECRET=REPLACE_WITH_SECRET

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-slim
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY . .
+EXPOSE 19006
+CMD ["npx", "expo", "start", "--web", "--no-interactive"]


### PR DESCRIPTION
## Summary
- add Dockerfile and env example for the frontend
- extend docker-compose with frontend service
- document frontend Docker usage in README
- clarify copying of `.env.example` files

## Testing
- `pytest -q`
- `npm test --silent` in `frontend`
- `npm test --silent` in `mobile`


------
https://chatgpt.com/codex/tasks/task_e_688878f0ff78832599464e51ce6f3dad