### PR TITLE
Fix expo flag in frontend Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,4 +4,4 @@ COPY package.json package-lock.json* ./
 RUN npm install
 COPY . .
 EXPOSE 19006
-CMD ["npx", "expo", "start", "--web", "--no-interactive"]
+CMD ["npx", "expo", "start", "--web", "--non-interactive"]


### PR DESCRIPTION
## Summary
- update Dockerfile to use `--non-interactive` flag

## Testing
- `pytest -q`
- `npm test --if-present` in `frontend`
- `npm test` in `mobile`


------
https://chatgpt.com/codex/tasks/task_e_688883406a90832592dd8d69094a6f2b