### PR TITLE
Add upgrade script to React Native apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This repository contains both the front-end and back-end code for the Consolidator application.
 
-* `frontend/` – an [Expo](https://expo.dev) React Native app.
-* `backend/` – a Flask API server.
+- `frontend/` – an [Expo](https://expo.dev) React Native app.
+- `backend/` – a Flask API server.
 
 Each part can be run and developed independently.
 
@@ -67,6 +67,7 @@ stable secret:
 ```bash
 export TOKENIZER_SECRET=my-secret-value
 ```
+
 If the variable is omitted a random salt is generated for each token.
 
 All payment flows additionally use a small client-side tokenization helper
@@ -220,8 +221,8 @@ with a default limit of `100/hour` per IP. Adjust this by setting the
 
 Your `DATABASE_URL` should use a standard SQLAlchemy connection string. For example:
 
-* **Postgres**: `postgresql://user:password@hostname:5432/dbname`
-* **MySQL**: `mysql+pymysql://user:password@hostname:3306/dbname`
+- **Postgres**: `postgresql://user:password@hostname:5432/dbname`
+- **MySQL**: `mysql+pymysql://user:password@hostname:3306/dbname`
 
 ## Database migrations
 
@@ -273,7 +274,7 @@ Join our community of developers creating universal apps.
 ## Deployment
 
 Create a `backend/.env` file before running the API in production. Copy the
-example file and replace each placeholder with your real credentials.  The
+example file and replace each placeholder with your real credentials. The
 application uses PostgreSQL in production, so set `DATABASE_URL` to the
 connection string for your Postgres instance (for example
 `postgresql://user:password@localhost:5432/consolidator`):
@@ -337,7 +338,6 @@ server {
 This keeps Gunicorn behind the reverse proxy while still serving the API on
 port 80.
 
-
 ## Windows installer
 
 A helper script is provided to build an executable version of the backend and install all dependencies. Run the following commands in a Windows command prompt:
@@ -397,3 +397,4 @@ records.
 ## Dependency upgrades
 
 See [docs/frontend-upgrade-plan.md](./docs/frontend-upgrade-plan.md) for the latest recommended Expo and React Native versions and how to update.
+Both React Native directories include an `upgrade` npm script. Run `npm run upgrade` within `frontend` or `mobile` to initiate `npx expo upgrade`.

--- a/docs/frontend-upgrade-plan.md
+++ b/docs/frontend-upgrade-plan.md
@@ -47,6 +47,7 @@ Other libraries with updates include:
 
 5. **Update documentation**
    - Document the new versions and any required configuration changes in `README.md`.
-   - Consider adding an upgrade script or notes in `package.json` scripts for future updates.
+   - A convenience `upgrade` script has been added to each React Native project's `package.json`.
+     Run `npm run upgrade` in the `frontend` or `mobile` directories to launch `npx expo upgrade` for future updates.
 
 These upgrades will keep the app on supported versions and ensure access to the latest features and security fixes.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "test": "jest"
+    "test": "jest",
+    "upgrade": "npx expo upgrade"
   },
   "dependencies": {
     "@react-navigation/bottom-tabs": "^7.2.0",

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -18,7 +18,7 @@ Use the on-screen options to run the app on a simulator, physical device or in t
 ## Login feature
 
 The app now starts on a **Login** screen. Provide your registered email and
-password and press **Login**.  On success you will be taken to the home screen
+password and press **Login**. On success you will be taken to the home screen
 which fetches session information from the backend.
 
 From the home screen you can navigate to additional flows:

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -8,7 +8,8 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "test": "jest tests"
+    "test": "jest tests",
+    "upgrade": "npx expo upgrade"
   },
   "dependencies": {
     "expo": "~52.0.4",


### PR DESCRIPTION
## Summary
- document upgrade script in docs and README
- add `upgrade` script to React Native package.json files
- format mobile README

## Testing
- `cd backend && pytest`
- `cd frontend && npm test`
- `cd mobile && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68891aa386fc8325831f5cd892d60a8f