### PR TITLE
Fix SQLAlchemy deprecation warnings

### DIFF
--- a/backend/tests/test_kyc.py
+++ b/backend/tests/test_kyc.py
@@ -1,4 +1,5 @@
 import os
+
 os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test")
 os.environ.setdefault("STRIPE_PUBLISHABLE_KEY", "pk_test")
 os.environ.setdefault("STRIPE_WEBHOOK_SECRET", "whsec_test")
@@ -36,7 +37,7 @@ def test_daily_limit_triggers_kyc(mocker):
             aml.log_transaction(user_id, 250, "purchase")
         profile = kyc.get_user_profile(user_id)
         assert profile.kyc_status == "pending"
-        db_profile = UserProfile.query.get(user_id)
+        db_profile = db.session.get(UserProfile, user_id)
         assert db_profile.verification_status == "pending"
 
 
@@ -48,7 +49,7 @@ def test_single_large_transaction_flagged(mocker):
         aml.log_transaction(user_id, 350, "purchase")
         profile = kyc.get_user_profile(user_id)
         assert profile.flagged is True
-        assert UserProfile.query.get(user_id).flagged is True
+        assert db.session.get(UserProfile, user_id).flagged is True
 
 
 def test_transaction_totals_persist():
@@ -63,7 +64,7 @@ def test_transaction_totals_persist():
         # ensure fetching again reflects stored totals
         profile2 = kyc.get_user_profile(user_id)
         assert profile2.daily_total == 150
-        db_profile = UserProfile.query.get(user_id)
+        db_profile = db.session.get(UserProfile, user_id)
         assert db_profile.daily_total == 150
         assert db_profile.weekly_total == 150
 
@@ -76,4 +77,3 @@ def test_card_balances_persist():
         kyc.update_card_balance(profile, 1, 20.0)
         profile2 = kyc.get_user_profile(user_id)
         assert profile2.card_balances == [(1, 20.0)]
-


### PR DESCRIPTION
## Summary
- update tests to use `db.session.get()` over `Query.get()`

## Testing
- `cd backend && pytest -q`
- `cd frontend && npm test --silent`
- `cd mobile && npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68891c433a2883259f2ea6bfd946fb83