### PR TITLE
Update React Native projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,3 +398,4 @@ records.
 
 See [docs/frontend-upgrade-plan.md](./docs/frontend-upgrade-plan.md) for the latest recommended Expo and React Native versions and how to update.
 Both React Native directories include an `upgrade` npm script. Run `npm run upgrade` within `frontend` or `mobile` to initiate `npx expo upgrade`.
+The apps currently target **Expo 53**, **React Native 0.80**, and **React 19.1.1** after the most recent upgrade.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,19 +11,19 @@
     "upgrade": "npx expo upgrade"
   },
   "dependencies": {
-    "@react-navigation/bottom-tabs": "^7.2.0",
-    "@react-navigation/native": "^7.0.14",
-    "@react-navigation/native-stack": "^7.2.0",
-    "@stripe/stripe-react-native": "~0.32.0",
+    "@react-navigation/bottom-tabs": "^7.4.4",
+    "@react-navigation/native": "^7.1.16",
+    "@react-navigation/native-stack": "^7.3.23",
+    "@stripe/stripe-react-native": "^0.50.1",
     "axios": "^1.6.2",
-    "expo": "~52.0.4",
-    "expo-router": "~4.0.18",
-    "expo-secure-store": "~12.2.0",
-    "expo-splash-screen": "~0.29.24",
-    "react": "18.2.0",
-    "react-native": "0.76.7",
-    "react-native-safe-area-context": "5.4.0",
-    "react-native-webview": "13.7.0"
+    "expo": "~53.0.20",
+    "expo-router": "~5.1.4",
+    "expo-secure-store": "~14.2.3",
+    "expo-splash-screen": "~0.30.10",
+    "react": "19.1.1",
+    "react-native": "0.80.2",
+    "react-native-safe-area-context": "5.5.2",
+    "react-native-webview": "13.15.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
@@ -34,7 +34,7 @@
     "jest-environment-jsdom": "^30.0.5",
     "jest-fetch-mock": "^3.0.3",
     "metro-react-native-babel-preset": "^0.77.0",
-    "react-test-renderer": "18.2.0"
+    "react-test-renderer": "19.1.1"
   },
   "private": true
 }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -12,13 +12,13 @@
     "upgrade": "npx expo upgrade"
   },
   "dependencies": {
-    "expo": "~52.0.4",
-    "react": "18.2.0",
-    "react-native": "0.76.7",
-    "@react-navigation/native": "^6.1.8",
-    "@react-navigation/native-stack": "^6.9.14",
-    "react-native-safe-area-context": "^4.8.2",
-    "react-native-screens": "^3.29.0"
+    "expo": "~53.0.20",
+    "react": "19.1.1",
+    "react-native": "0.80.2",
+    "@react-navigation/native": "^7.1.16",
+    "@react-navigation/native-stack": "^7.3.23",
+    "react-native-safe-area-context": "^5.5.2",
+    "react-native-screens": "^4.13.1"
   },
   "devDependencies": {
     "babel-jest": "^30.0.5",


### PR DESCRIPTION
## Summary
- bump Expo & React Native versions in `frontend` and `mobile`
- record new target versions in README

## Testing
- `cd backend && pytest`
- `cd frontend && npm test --silent`
- `cd mobile && npm test`
- `npm run upgrade` (frontend and mobile, fails due to unsupported local CLI)

------
https://chatgpt.com/codex/tasks/task_e_6889210ddaf08325b9b19bca98a865d4