### PR TITLE
Expand tests and split CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,49 +5,57 @@ on:
   pull_request:
 
 jobs:
-  test:
+  backend:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-
-      - name: Install backend dependencies
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r backend/requirements.txt
-
-      - name: Run backend tests
+      - name: Run tests
         run: |
           cd backend
           pytest
 
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
           node-version: '18'
           cache: 'npm'
-          cache-dependency-path: |
-            frontend/package-lock.json
-            mobile/package-lock.json
-
-      - name: Install frontend dependencies
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install dependencies
         run: |
           cd frontend
           npm ci
-
-      - name: Run frontend tests
+      - name: Run tests
         run: |
           cd frontend
           npm test --if-present
 
-      - name: Install mobile dependencies
-        working-directory: mobile
-        run: npm ci
-
-      - name: Run mobile tests
-        working-directory: mobile
-        run: npm test
+  mobile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: mobile/package-lock.json
+      - name: Install dependencies
+        run: |
+          cd mobile
+          npm ci
+      - name: Run tests
+        run: |
+          cd mobile
+          npm test

--- a/frontend/tests/authScreens.test.js
+++ b/frontend/tests/authScreens.test.js
@@ -1,0 +1,90 @@
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+
+jest.mock("react-native", () => {
+  const React = require("react");
+  return {
+    View: (props) => React.createElement("View", props, props.children),
+    Text: (props) => React.createElement("Text", props, props.children),
+    TextInput: (props) => React.createElement("TextInput", props),
+    Button: (props) => React.createElement("Button", props),
+    TouchableOpacity: (props) =>
+      React.createElement("TouchableOpacity", props, props.children),
+    StyleSheet: { create: (styles) => styles },
+    useColorScheme: () => "light",
+  };
+});
+
+jest.mock("../SecureStore", () => ({
+  getItem: jest.fn(),
+  saveItem: jest.fn(),
+  deleteItem: jest.fn(),
+}));
+
+import LoginScreen from "../LoginScreen";
+import RegisterScreen from "../RegisterScreen";
+import { AuthContext } from "../AuthContext";
+
+describe("auth screens", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test("LoginScreen shows error message on failed login", async () => {
+    const login = jest.fn().mockResolvedValue({ error: "invalid credentials" });
+    let tree;
+    await act(async () => {
+      tree = renderer.create(
+        <AuthContext.Provider value={{ login }}>
+          <LoginScreen navigation={{ navigate: jest.fn() }} />
+        </AuthContext.Provider>,
+      );
+    });
+    const root = tree.root;
+    const emailInput = root.findByProps({ placeholder: "Email" });
+    const passwordInput = root.findByProps({ placeholder: "Password" });
+    await act(async () => {
+      emailInput.props.onChangeText("user@example.com");
+      passwordInput.props.onChangeText("secret");
+    });
+    const button = root.findByProps({ title: "Login" });
+    await act(async () => {
+      button.props.onPress();
+    });
+    expect(login).toHaveBeenCalledWith("user@example.com", "secret");
+    const text = root
+      .findAllByType(require("react-native").Text)
+      .find((t) => t.props.children === "invalid credentials");
+    expect(text).toBeTruthy();
+  });
+
+  test("RegisterScreen shows error message on failed register", async () => {
+    const register = jest.fn().mockResolvedValue({ error: "email taken" });
+    let tree;
+    await act(async () => {
+      tree = renderer.create(
+        <AuthContext.Provider value={{ register }}>
+          <RegisterScreen navigation={{ navigate: jest.fn() }} />
+        </AuthContext.Provider>,
+      );
+    });
+    const root = tree.root;
+    const nameInput = root.findByProps({ placeholder: "Name" });
+    const emailInput = root.findByProps({ placeholder: "Email" });
+    const passwordInput = root.findByProps({ placeholder: "Password" });
+    await act(async () => {
+      nameInput.props.onChangeText("User");
+      emailInput.props.onChangeText("user@example.com");
+      passwordInput.props.onChangeText("secret");
+    });
+    const button = root.findByProps({ title: "Register" });
+    await act(async () => {
+      button.props.onPress();
+    });
+    expect(register).toHaveBeenCalledWith("User", "user@example.com", "secret");
+    const text = root
+      .findAllByType(require("react-native").Text)
+      .find((t) => t.props.children === "email taken");
+    expect(text).toBeTruthy();
+  });
+});

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,3 +1,6 @@
 module.exports = {
-  presets: [["@babel/preset-env", { targets: { node: 'current' } }]],
+  presets: [
+    ["@babel/preset-env", { targets: { node: "current" } }],
+    "@babel/preset-react",
+  ],
 };

--- a/mobile/tests/screenFlows.test.js
+++ b/mobile/tests/screenFlows.test.js
@@ -1,0 +1,73 @@
+const React = require("../../frontend/node_modules/react");
+const renderer = require("../../frontend/node_modules/react-test-renderer");
+const { act } = renderer;
+jest.mock("react", () => require("../../frontend/node_modules/react"));
+
+jest.mock("react-native", () => {
+  const React = require("react");
+  return {
+    View: (props) => React.createElement("View", props, props.children),
+    Text: (props) => React.createElement("Text", props, props.children),
+    TextInput: (props) => React.createElement("TextInput", props),
+    Button: (props) => React.createElement("Button", props),
+    ActivityIndicator: (props) =>
+      React.createElement("ActivityIndicator", props),
+    StyleSheet: { create: (styles) => styles },
+  };
+});
+
+import LoginScreen from "../LoginScreen";
+import BankLinkScreen from "../BankLinkScreen";
+import { loginUser, sessionInfo, linkBankAccount } from "../api";
+
+jest.mock("../api");
+
+describe("mobile screens", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test("LoginScreen displays error on failed login", async () => {
+    loginUser.mockResolvedValue({ error: "Invalid" });
+    sessionInfo.mockResolvedValue({});
+    let tree;
+    const navigation = { replace: jest.fn() };
+    await act(async () => {
+      tree = renderer.create(React.createElement(LoginScreen, { navigation }));
+    });
+    const root = tree.root;
+    const emailInput = root.findByProps({ placeholder: "Email" });
+    const passwordInput = root.findByProps({ placeholder: "Password" });
+    await act(async () => {
+      emailInput.props.onChangeText("user@example.com");
+      passwordInput.props.onChangeText("secret");
+    });
+    const button = root.findByProps({ title: "Login" });
+    await act(async () => {
+      button.props.onPress();
+    });
+    expect(loginUser).toHaveBeenCalledWith("user@example.com", "secret");
+    const text = root
+      .findAllByType(require("react-native").Text)
+      .find((t) => t.props.children === "Invalid");
+    expect(text).toBeTruthy();
+  });
+
+  test("BankLinkScreen warns when token missing", async () => {
+    sessionInfo.mockResolvedValue({ authenticated: true, user_id: 1 });
+    let tree;
+    await act(async () => {
+      tree = renderer.create(React.createElement(BankLinkScreen));
+    });
+    const root = tree.root;
+    const button = root.findByProps({ title: "Link" });
+    await act(async () => {
+      button.props.onPress();
+    });
+    const text = root
+      .findAllByType(require("react-native").Text)
+      .find((t) => t.props.children === "Enter bank token");
+    expect(text).toBeTruthy();
+    expect(linkBankAccount).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- split CI into backend, frontend, and mobile jobs
- add frontend login/register error flow tests
- add mobile login and bank link edge case tests
- enable React JSX transform for mobile tests

## Testing
- `cd backend && pytest`
- `cd frontend && npm test`
- `cd mobile && npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e9b6de078832582df795af26318b9