### PR TITLE
fix: remove deprecated expo router babel plugin

### DIFF
--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -1,8 +1,8 @@
 module.exports = {
   presets: [
-    'module:metro-react-native-babel-preset',
-    ["@babel/preset-env", { targets: { node: 'current' } }],
-    '@babel/preset-react',
+    "babel-preset-expo",
+    ["@babel/preset-env", { targets: { node: "current" } }],
+    "@babel/preset-react",
   ],
-  plugins: ['expo-router/babel'],
+  plugins: [],
 };


### PR DESCRIPTION
## Summary
- replace deprecated `expo-router/babel` plugin with `babel-preset-expo`

## Testing
- `cd backend && pytest -q`
- `cd frontend && npm test`
- `cd mobile && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ebf373d58832594cf58820811c253