### PR TITLE
chore: add dependabot and node matrix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/mobile"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
     steps:
       - uses: actions/checkout@v3
 
@@ -28,7 +31,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: ${{ matrix.node-version }}
           cache: 'npm'
           cache-dependency-path: |
             frontend/package-lock.json


### PR DESCRIPTION
## Summary
- add Dependabot config for backend, frontend, mobile, and GitHub Actions
- expand CI workflow to test against Node 18.x, 20.x, and 22.x

## Testing
- `cd backend && pytest`
- `cd frontend && npm test`
- `cd mobile && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ec8ff115883259d36229695dd846e