### PR TITLE
fix(frontend): install web deps and enable CI mode

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,8 @@
 FROM node:22-slim
 WORKDIR /app
 COPY package.json package-lock.json* ./
-RUN npm install
+ENV CI=1
+RUN npm install && npx expo install react-native-web
 COPY . .
 EXPOSE 19006
-CMD ["npx", "expo", "start", "--web", "--no-interactive"]
+CMD ["npx", "expo", "start", "--web"]


### PR DESCRIPTION
## Summary
- set CI environment variable so Expo runs without prompts in Docker
- install `react-native-web` during frontend Docker build for web support

## Testing
- `cd backend && pytest`
- `cd frontend && npm test`
- `cd mobile && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ee3634c2c83258313db90c3787e91