### PR TITLE
chore(frontend): add TypeScript deps

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,10 +26,12 @@
         "@babel/core": "^7.28.0",
         "@babel/preset-env": "^7.28.0",
         "@testing-library/react-native": "^13.2.2",
+        "@types/react": "^19.1.9",
         "babel-jest": "^30.0.5",
         "jest": "^30.0.5",
         "metro-react-native-babel-preset": "^0.77.0",
-        "react-test-renderer": "19.1.1"
+        "react-test-renderer": "19.1.1",
+        "typescript": "^5.9.2"
       },
       "engines": {
         "node": "22.17.1"
@@ -4446,6 +4448,16 @@
         "undici-types": "~7.8.0"
       }
     },
+    "node_modules/@types/react": {
+      "version": "19.1.9",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.9.tgz",
+      "integrity": "sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -5867,6 +5879,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -12687,6 +12706,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,10 +29,12 @@
     "@babel/core": "^7.28.0",
     "@babel/preset-env": "^7.28.0",
     "@testing-library/react-native": "^13.2.2",
+    "@types/react": "^19.1.9",
     "babel-jest": "^30.0.5",
     "jest": "^30.0.5",
     "metro-react-native-babel-preset": "^0.77.0",
-    "react-test-renderer": "19.1.1"
+    "react-test-renderer": "19.1.1",
+    "typescript": "^5.9.2"
   },
   "private": true,
   "engines": {


### PR DESCRIPTION
## Summary
- add TypeScript and React type definitions for Expo frontend

## Testing
- `cd backend && pytest`
- `cd frontend && npm test`
- `cd mobile && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ef0964dd083259c416809a58f110a